### PR TITLE
chore: bootstrap android project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: "8.11.1"
+
+      - name: Spotless check
+        run: gradle spotlessCheck
+
+      - name: Lint
+        run: gradle lintDebug
+
+      - name: Unit tests
+        run: gradle testDebugUnitTest
+
+      - name: Assemble debug
+        run: gradle assembleDebug

--- a/README.md
+++ b/README.md
@@ -23,9 +23,33 @@ Pre-alpha. Scaffold + requirements only. Android project not yet generated.
 - [Requirements](docs/REQUIREMENTS.md) — what the app does, in detail
 - [Design](docs/DESIGN.md) — high-level architecture, pace curves, auth flow
 
+## Getting started
+
+Project uses the Gradle **version catalog** (`gradle/libs.versions.toml`) and ships without the Gradle Wrapper binaries. First time after cloning:
+
+```bash
+# Option A — open in Android Studio; "Sync Project" generates the wrapper.
+# Option B — from the command line, with Gradle installed locally:
+gradle wrapper --gradle-version 8.11.1
+./gradlew assembleDebug
+```
+
+**Build targets:**
+- `./gradlew spotlessCheck` — formatting check
+- `./gradlew spotlessApply` — auto-format
+- `./gradlew lintDebug` — Android lint
+- `./gradlew testDebugUnitTest` — unit tests
+- `./gradlew assembleDebug` — build the APK
+
+**Spotify client ID:**
+The Spotify client ID is read from `local.properties` (not committed). Add:
+
+```
+SPOTIFY_CLIENT_ID=your_public_client_id_here
+```
+
+There is no client secret — we use Authorization Code Flow with PKCE.
+
 ## Next steps
 
-1. Generate Android Studio project scaffold (Kotlin + Compose).
-2. Register the app in the Spotify Developer Dashboard and wire up PKCE auth.
-3. Prototype the pacing engine (BPM curve → track selection).
-4. Minimal UI: distance/time input → pace preview → track list → approve → save.
+Tracked in the [v0.1 MVP milestone](https://github.com/sebastiankdittmann/spotify-pacer/milestones) and the tracking issue (once opened).

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,0 +1,59 @@
+plugins {
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.kotlin.compose)
+}
+
+android {
+    namespace = "dk.dittmann.spotifypacer"
+    compileSdk = 35
+
+    defaultConfig {
+        applicationId = "dk.dittmann.spotifypacer"
+        minSdk = 29
+        targetSdk = 35
+        versionCode = 1
+        versionName = "0.1.0"
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro",
+            )
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions { jvmTarget = "17" }
+
+    buildFeatures { compose = true }
+}
+
+dependencies {
+    implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.lifecycle.runtime.ktx)
+    implementation(libs.androidx.activity.compose)
+    implementation(platform(libs.androidx.compose.bom))
+    implementation(libs.androidx.ui)
+    implementation(libs.androidx.ui.graphics)
+    implementation(libs.androidx.ui.tooling.preview)
+    implementation(libs.androidx.material3)
+
+    testImplementation(libs.junit)
+
+    androidTestImplementation(libs.androidx.junit)
+    androidTestImplementation(libs.androidx.espresso.core)
+    androidTestImplementation(platform(libs.androidx.compose.bom))
+    androidTestImplementation(libs.androidx.ui.test.junit4)
+
+    debugImplementation(libs.androidx.ui.tooling)
+    debugImplementation(libs.androidx.ui.test.manifest)
+}

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,0 +1,2 @@
+# Project-specific ProGuard rules go here.
+# Defaults from Android SDK are applied via proguard-android-optimize.txt.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <application
+        android:allowBackup="true"
+        android:label="@string/app_name"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.SpotifyPacer">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/app/src/main/java/dk/dittmann/spotifypacer/MainActivity.kt
+++ b/app/src/main/java/dk/dittmann/spotifypacer/MainActivity.kt
@@ -1,0 +1,40 @@
+package dk.dittmann.spotifypacer
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+        setContent {
+            MaterialTheme {
+                Surface(modifier = Modifier.fillMaxSize()) { Landing() }
+            }
+        }
+    }
+}
+
+@Composable
+fun Landing(modifier: Modifier = Modifier) {
+    Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Text(text = "spotify-pacer")
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun LandingPreview() {
+    MaterialTheme { Landing() }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Spotify Pacer</string>
+</resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.SpotifyPacer" parent="android:Theme.Material.Light.NoActionBar" />
+</resources>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,18 @@
+plugins {
+    alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.kotlin.android) apply false
+    alias(libs.plugins.kotlin.compose) apply false
+    alias(libs.plugins.spotless)
+}
+
+spotless {
+    kotlin {
+        target("**/*.kt")
+        targetExclude("**/build/**", "**/.gradle/**")
+        ktfmt("0.53").kotlinlangStyle()
+    }
+    kotlinGradle {
+        target("**/*.gradle.kts")
+        ktfmt("0.53").kotlinlangStyle()
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,9 @@
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.caching=true
+org.gradle.parallel=true
+org.gradle.configuration-cache=true
+
+android.useAndroidX=true
+android.nonTransitiveRClass=true
+
+kotlin.code.style=official

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,33 @@
+[versions]
+agp = "8.7.3"
+kotlin = "2.1.0"
+coreKtx = "1.15.0"
+lifecycleRuntimeKtx = "2.8.7"
+activityCompose = "1.9.3"
+composeBom = "2024.12.01"
+junit = "4.13.2"
+androidxJunit = "1.2.1"
+espressoCore = "3.6.1"
+spotless = "6.25.0"
+
+[libraries]
+androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
+androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
+androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
+androidx-ui = { group = "androidx.compose.ui", name = "ui" }
+androidx-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
+androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
+androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
+androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
+androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
+androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+junit = { group = "junit", name = "junit", version.ref = "junit" }
+androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidxJunit" }
+androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
+
+[plugins]
+android-application = { id = "com.android.application", version.ref = "agp" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,24 @@
+pluginManagement {
+    repositories {
+        google {
+            content {
+                includeGroupByRegex("com\\.android.*")
+                includeGroupByRegex("com\\.google.*")
+                includeGroupByRegex("androidx.*")
+            }
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "spotify-pacer"
+include(":app")


### PR DESCRIPTION
Scaffolds the Android project so further issues have a place to land.

## What's in
- Kotlin 2.1.0 + Jetpack Compose (BOM 2024.12.01)
- Android Gradle Plugin 8.7.3, compile/target SDK 35, min SDK 29
- Gradle version catalog at `gradle/libs.versions.toml`
- Spotless + ktfmt formatting
- CI workflow: spotless, lint, unit tests, assembleDebug on PRs to main
- Placeholder `MainActivity` rendering "spotify-pacer"
- Package: `dk.dittmann.spotifypacer`

## Follow-ups
- Open in Android Studio (or run `gradle wrapper --gradle-version 8.11.1`) once to generate wrapper binaries; commit them in a follow-up PR.
- Add Spotify client ID placeholder to `local.properties` when auth work starts (LRMP ticket TBD).

## Not in scope
Any auth, API client, pacing engine, or real UI — each tracked in its own issue under the v0.1 MVP milestone.