### PR TITLE
chore: wire compose preview screenshots for copilot PRs

### DIFF
--- a/.github/copilot-code-review-instructions.md
+++ b/.github/copilot-code-review-instructions.md
@@ -38,6 +38,13 @@ Review the diff against the principles below. Comment only when you have a concr
 - **Dependence on `audio-features`** — deprecated for newer app registrations; flag if the PR adds a new code path relying on it with no fallback.
 - **Unbounded Spotify calls** — no caching, no pagination, no rate-limit handling on loops that hit the API per track.
 
+## UI PR screenshots
+
+- **Missing screenshots on a UI PR** — a PR that adds or changes a Compose composable must embed `@Preview` screenshots in the description. If absent, flag and link to `.github/copilot-instructions.md#screenshots-for-ui-prs`.
+- **New composable without a matching `@Preview` in the screenshot source set** — the preview is what drives the generated PNG. Flag missing entries in `app/src/screenshotTest/java/...`.
+- **Reference PNGs changed without a description of the visual change** — if `app/src/debug/screenshotTest/reference/**.png` is modified, the PR description should say what changed and why. Silent visual regressions are the thing this setup is designed to catch.
+- **Screenshot tests skipped** — flag CI workflow diffs that disable `validateDebugScreenshotTest`.
+
 ## PR hygiene
 
 - **Mixed concerns** — unrelated changes bundled in one PR. Suggest splitting.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -40,6 +40,27 @@ Apply these in every suggestion. They override any stylistic default.
 - `audio-features` may be deprecated for new app registrations — flag if a suggestion depends on it without a fallback plan.
 - Cache audio-features locally; Spotify rate-limits aggressively.
 
+## Screenshots for UI PRs
+
+Any PR that adds or changes a Compose UI **must** include screenshots in the PR description. The repo is wired for headless, JVM-rendered screenshots via the `com.android.compose.screenshot` plugin — no emulator needed.
+
+**Workflow:**
+
+1. Write your composable in `app/src/main/java/...`.
+2. Mirror each visual state as a `@Preview` function in `app/src/screenshotTest/java/dk/dittmann/spotifypacer/...` (e.g. `LoginPreviewTest.kt` with `LoginIdlePreview`, `LoginLoadingPreview`, `LoginErrorPreview`, `LoginSuccessPreview`).
+3. Run `./gradlew :app:updateDebugScreenshotTest` to generate reference PNGs. They land under `app/src/debug/screenshotTest/reference/...`.
+4. Commit both the source previews and the reference PNGs on the PR branch.
+5. Embed each screenshot in the PR description using a relative path:
+
+   ```markdown
+   ## Screenshots
+   | State | Image |
+   |---|---|
+   | Idle | ![idle](app/src/debug/screenshotTest/reference/dk/dittmann/spotifypacer/ui/login/LoginPreviewTest_LoginIdlePreview.png) |
+   ```
+
+**CI enforces this:** `gradle validateDebugScreenshotTest` runs on every PR. If the committed reference PNGs don't match what the `@Preview`s now render, CI fails — regenerate and re-commit.
+
 ## PR and commit conventions
 
 - Small, focused PRs. One concern per PR.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,5 +33,16 @@ jobs:
       - name: Unit tests
         run: gradle testDebugUnitTest
 
+      - name: Validate preview screenshots
+        run: gradle validateDebugScreenshotTest
+
       - name: Assemble debug
         run: gradle assembleDebug
+
+      - name: Upload screenshot diffs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: screenshot-diffs
+          path: app/build/outputs/screenshot-test-results/**
+          if-no-files-found: ignore

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,38 @@
+name: Copilot Setup Steps
+
+# This workflow defines the environment GitHub Copilot's coding agent should
+# inherit when it starts work on this repo. The agent runs the
+# `copilot-setup-steps` job once in its ephemeral sandbox before editing code.
+#
+# Keep this aligned with .github/workflows/ci.yml so the agent sees the same
+# toolchain CI uses: if `./gradlew lintDebug testDebugUnitTest
+# validateDebugScreenshotTest` passes here, it will pass in CI.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: "8.11.1"
+
+      - name: Warm Gradle cache
+        run: gradle help --no-daemon

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.compose.screenshot)
 }
 
 android {
@@ -35,6 +36,8 @@ android {
     kotlinOptions { jvmTarget = "17" }
 
     buildFeatures { compose = true }
+
+    experimentalProperties["android.experimental.enableScreenshotTest"] = true
 }
 
 dependencies {
@@ -56,4 +59,7 @@ dependencies {
 
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
+
+    screenshotTestImplementation(platform(libs.androidx.compose.bom))
+    screenshotTestImplementation(libs.androidx.ui.tooling)
 }

--- a/app/src/screenshotTest/java/dk/dittmann/spotifypacer/LandingPreviewTest.kt
+++ b/app/src/screenshotTest/java/dk/dittmann/spotifypacer/LandingPreviewTest.kt
@@ -1,0 +1,19 @@
+package dk.dittmann.spotifypacer
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+
+/**
+ * Preview screenshot tests. Every @Preview here is rendered to PNG by
+ * `./gradlew :app:updateDebugScreenshotTest` (reference images) and compared by
+ * `./gradlew :app:validateDebugScreenshotTest` (CI).
+ *
+ * When you add a new screen, mirror its @Preview variants in this source set so
+ * screenshots show up in PRs.
+ */
+@Preview(name = "landing_light", showBackground = true)
+@Composable
+fun LandingLightPreview() {
+    MaterialTheme { Landing() }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ junit = "4.13.2"
 androidxJunit = "1.2.1"
 espressoCore = "3.6.1"
 spotless = "6.25.0"
+screenshot = "0.0.1-alpha09"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -31,3 +32,4 @@ android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
+compose-screenshot = { id = "com.android.compose.screenshot", version.ref = "screenshot" }


### PR DESCRIPTION
Enables JVM-rendered Compose previews so Copilot (and humans) can attach screenshots to UI PRs without an emulator.

## What's in
- `com.android.compose.screenshot` plugin applied to `:app` with the experimental flag enabled.
- Example `LandingPreviewTest` under `app/src/screenshotTest/java/...` demonstrating the pattern.
- CI: `validateDebugScreenshotTest` runs on every PR; diff artifacts uploaded on failure.
- `.github/workflows/copilot-setup-steps.yml` — primes the Copilot coding-agent sandbox with JDK 17 + Android SDK + Gradle 8.11.1.
- `copilot-instructions.md` gains a **Screenshots** section; `copilot-code-review-instructions.md` gains matching review rules.

## Follow-ups (Seb, local)
1. `./gradlew :app:updateDebugScreenshotTest` to generate the first reference PNGs.
2. Commit the PNGs in a follow-up PR so CI has a baseline.

## Not in scope
- Updating the 4 UI issue bodies — that happens right after this PR merges.