### PR TITLE
feat: robolectric-hosted compose UI tests for PR CI

### DIFF
--- a/.github/copilot-code-review-instructions.md
+++ b/.github/copilot-code-review-instructions.md
@@ -38,6 +38,15 @@ Review the diff against the principles below. Comment only when you have a concr
 - **Dependence on `audio-features`** — deprecated for newer app registrations; flag if the PR adds a new code path relying on it with no fallback.
 - **Unbounded Spotify calls** — no caching, no pagination, no rate-limit handling on loops that hit the API per track.
 
+## UI PR behavior tests
+
+- **Missing UI test on a UI PR** — a PR that adds or changes a Compose composable must include at least one Robolectric-hosted behavior test under `app/src/test/java/...`. If absent, flag and link to `.github/copilot-instructions.md#ui-behavior-tests`.
+- **State transitions untested** — if the screen has multiple states (`Idle | Loading | Error | Success`), flag if only one is covered.
+- **Interactive element without an assertion** — button or input wired in the PR but not exercised by a test. Flag.
+- **Test asserts implementation, not behavior** — e.g. checking a specific Modifier chain instead of a visible effect (text shown, state changed). Suggest behavioral assertion.
+- **Shared fixtures duplicated inline** — if three tests copy-paste the same setup, suggest a small helper.
+- **Emulator/instrumentation test added** — flag: the project targets Robolectric unit tests only (`test/` source set). If a real emulator flow is needed, open a discussion first.
+
 ## UI PR screenshots
 
 - **Missing screenshots on a UI PR** — a PR that adds or changes a Compose composable must embed `@Preview` screenshots in the description. If absent, flag and link to `.github/copilot-instructions.md#screenshots-for-ui-prs`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -40,6 +40,37 @@ Apply these in every suggestion. They override any stylistic default.
 - `audio-features` may be deprecated for new app registrations — flag if a suggestion depends on it without a fallback plan.
 - Cache audio-features locally; Spotify rate-limits aggressively.
 
+## UI behavior tests
+
+Any PR that adds or changes a Compose UI **must** include or update a UI behavior test. Tests live in `app/src/test/java/dk/dittmann/spotifypacer/...` and run on the JVM via Robolectric — no emulator needed, no sandbox setup beyond what's already configured.
+
+**Pattern:**
+
+```kotlin
+@RunWith(RobolectricTestRunner::class)
+class LoginScreenTest {
+    @get:Rule val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun tapping_sign_in_shows_loading() {
+        composeRule.setContent { LoginScreen(state = LoginState.Idle, onSignIn = {}) }
+        composeRule.onNodeWithText("Sign in with Spotify").performClick()
+        // assert state transition
+    }
+}
+```
+
+**What to test:**
+- Each visible state the screen can render (idle/loading/error/success) — one test each.
+- Every interactive affordance (button, input) — assert the state change it causes.
+- Navigation triggers (e.g. button tap emits a nav event) — assert via a test double for the callback.
+
+**What NOT to test here:**
+- Pure logic already covered by unit tests (curve math, selection algorithm). Don't duplicate.
+- Integration against real Spotify — use fakes/mocks.
+
+**CI runs `gradle testDebugUnitTest` on every PR.** Failing UI behavior tests block merge.
+
 ## Screenshots for UI PRs
 
 Any PR that adds or changes a Compose UI **must** include screenshots in the PR description. The repo is wired for headless, JVM-rendered screenshots via the `com.android.compose.screenshot` plugin — no emulator needed.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,6 +38,8 @@ android {
     buildFeatures { compose = true }
 
     experimentalProperties["android.experimental.enableScreenshotTest"] = true
+
+    testOptions { unitTests { isIncludeAndroidResources = true } }
 }
 
 dependencies {
@@ -51,6 +53,10 @@ dependencies {
     implementation(libs.androidx.material3)
 
     testImplementation(libs.junit)
+    testImplementation(libs.robolectric)
+    testImplementation(platform(libs.androidx.compose.bom))
+    testImplementation(libs.androidx.ui.test.junit4)
+    testImplementation(libs.androidx.ui.test.manifest)
 
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/test/java/dk/dittmann/spotifypacer/LandingScreenTest.kt
+++ b/app/src/test/java/dk/dittmann/spotifypacer/LandingScreenTest.kt
@@ -1,0 +1,22 @@
+package dk.dittmann.spotifypacer
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class LandingScreenTest {
+
+    @get:Rule val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun shows_app_name() {
+        composeRule.setContent { Landing() }
+        composeRule.onNodeWithText("spotify-pacer").assertIsDisplayed()
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ androidxJunit = "1.2.1"
 espressoCore = "3.6.1"
 spotless = "6.25.0"
 screenshot = "0.0.1-alpha09"
+robolectric = "4.14.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -26,6 +27,7 @@ androidx-material3 = { group = "androidx.compose.material3", name = "material3" 
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidxJunit" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
+robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Adds a JVM-hosted UI behavior test stack so PRs that touch Compose code are gated on real-ish UI assertions without running an emulator.

## What's in
- Robolectric 4.14.1 + `compose-ui-test-junit4` + `ui-test-manifest` as `testImplementation`.
- `android { testOptions { unitTests { isIncludeAndroidResources = true } } }` so Robolectric sees real app resources.
- Example `LandingScreenTest` under `app/src/test/java/...` using `createAndroidComposeRule<ComponentActivity>()`.
- `copilot-instructions.md` gains a **UI behavior tests** section with the pattern and coverage rules.
- `copilot-code-review-instructions.md` gets matching review rules.

## CI
Existing `gradle testDebugUnitTest` runs these on every PR. Once this merges, branch protection will be tightened to make `build` a required status check — `gh pr merge` will refuse to merge when CI is red.

## Not in scope
- Emulator / instrumentation tests (`androidTest/`).
- Updating UI issue bodies with test AC — that's the follow-up step.