### PR TITLE
docs: expand README with running and testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,48 +8,82 @@ Login uses Spotify's **Authorization Code Flow with PKCE** so the app acts on be
 
 ## Status
 
-Pre-alpha. Scaffold + requirements only. Android project not yet generated.
+Pre-alpha. Android project scaffolded, CI green, no feature code yet. Work tracked under the [v0.1 MVP milestone](https://github.com/sebastiankdittmann/spotify-pacer/milestones).
 
 ## Stack
 
-- **Language**: Kotlin
-- **UI**: Jetpack Compose
-- **Min SDK**: TBD (target: Android 10+, API 29)
-- **Auth**: Spotify Authorization Code Flow with PKCE
-- **Spotify API**: Web API (search, audio-features, playlists)
+- **Language:** Kotlin 2.1
+- **UI:** Jetpack Compose (BOM 2024.12.01)
+- **Min SDK:** 29 (Android 10), compile & target SDK 35
+- **AGP:** 8.7.3
+- **Auth:** Spotify Authorization Code Flow with PKCE
+- **Tests:** JUnit 4 + Robolectric (Compose UI behavior tests on the JVM)
+- **Screenshots:** `com.android.compose.screenshot` plugin (JVM-rendered `@Preview` → PNG)
 
 ## Docs
 
-- [Requirements](docs/REQUIREMENTS.md) — what the app does, in detail
-- [Design](docs/DESIGN.md) — high-level architecture, pace curves, auth flow
+- [Requirements](docs/REQUIREMENTS.md)
+- [Design](docs/DESIGN.md)
+
+## Prerequisites
+
+- **Android Studio Ladybug** (2024.2.1) or newer — needed for the Compose screenshot-test plugin. [Download](https://developer.android.com/studio).
+- **JDK 17** — bundled with Android Studio; Gradle uses it automatically.
+- A Spotify account (free works) plus a **Spotify Developer app** — register at <https://developer.spotify.com/dashboard> when you start on the auth issue. Redirect URI: `spotifypacer://callback`.
 
 ## Getting started
 
-Project uses the Gradle **version catalog** (`gradle/libs.versions.toml`) and ships without the Gradle Wrapper binaries. First time after cloning:
+1. Clone the repo:
+   ```bash
+   git clone https://github.com/sebastiankdittmann/spotify-pacer.git
+   cd spotify-pacer
+   ```
+2. Open the project folder in Android Studio.
+3. Wait for **Gradle Sync** to finish. First sync downloads AGP, Kotlin, Compose, and the Android SDK components, and generates the Gradle wrapper (`gradlew`, `gradle/wrapper/gradle-wrapper.jar`).
+4. When the auth code lands ([issue #2](https://github.com/sebastiankdittmann/spotify-pacer/issues/2)), create `local.properties` in the project root:
+   ```properties
+   SPOTIFY_CLIENT_ID=paste_your_public_client_id_here
+   ```
+   `local.properties` is gitignored. There is no client secret — PKCE is used.
 
-```bash
-# Option A — open in Android Studio; "Sync Project" generates the wrapper.
-# Option B — from the command line, with Gradle installed locally:
-gradle wrapper --gradle-version 8.11.1
-./gradlew assembleDebug
-```
+## Running the app
 
-**Build targets:**
-- `./gradlew spotlessCheck` — formatting check
-- `./gradlew spotlessApply` — auto-format
-- `./gradlew lintDebug` — Android lint
-- `./gradlew testDebugUnitTest` — unit tests
-- `./gradlew assembleDebug` — build the APK
+### On an emulator (recommended for dev)
 
-**Spotify client ID:**
-The Spotify client ID is read from `local.properties` (not committed). Add:
+1. **Tools → Device Manager** (or the sidebar icon) → **Create Virtual Device**.
+2. Pick **Pixel 7** (or any recent profile), select system image **Android 15 · API 35 · Google APIs**, finish.
+3. Click ▶ on the device entry to boot it.
+4. With the emulator running, click the green **Run 'app'** button in the toolbar (or `⌃R` on macOS, `Shift+F10` on Windows/Linux).
 
-```
-SPOTIFY_CLIENT_ID=your_public_client_id_here
-```
+### On a physical device
 
-There is no client secret — we use Authorization Code Flow with PKCE.
+1. On the phone: **Settings → About phone** → tap **Build number** seven times to unlock developer mode → **Developer options → USB debugging: ON**.
+2. Plug in via USB. Accept the debug prompt the phone shows.
+3. The device appears in the Android Studio toolbar dropdown. Select it and hit **Run 'app'**.
 
-## Next steps
+## Running tests
 
-Tracked in the [v0.1 MVP milestone](https://github.com/sebastiankdittmann/spotify-pacer/milestones) and the tracking issue (once opened).
+### From Android Studio
+
+- Right-click `app/src/test/java` → **Run 'Tests in 'test''** — JVM unit tests, including Robolectric-hosted Compose UI tests.
+- Right-click a file under `app/src/screenshotTest/java` → **Run** — regenerates reference PNGs for the `@Preview` composables in that file.
+
+### From the command line
+
+After Android Studio has generated the Gradle wrapper at least once:
+
+| Command | What it does |
+|---|---|
+| `./gradlew testDebugUnitTest` | Unit tests + Robolectric Compose UI tests |
+| `./gradlew :app:updateDebugScreenshotTest` | (Re)generate `@Preview` reference PNGs |
+| `./gradlew :app:validateDebugScreenshotTest` | Check committed references against fresh renders |
+| `./gradlew lintDebug` | Android lint |
+| `./gradlew spotlessCheck` / `spotlessApply` | Check / auto-format Kotlin |
+| `./gradlew assembleDebug` | Build a debug APK |
+| `./gradlew installDebug` | Install on the connected device/emulator |
+
+CI runs `spotlessCheck → lintDebug → testDebugUnitTest → validateDebugScreenshotTest → assembleDebug` on every PR. `build` is a required status check on `main`.
+
+## Contributing
+
+This is a solo hobby project. Forks are welcome; only Seb (repo owner) merges. Coding rules live in [`.github/copilot-instructions.md`](.github/copilot-instructions.md); review rules in [`.github/copilot-code-review-instructions.md`](.github/copilot-code-review-instructions.md). These apply equally to humans and Copilot.


### PR DESCRIPTION
Expands the README with practical setup and run steps now that the scaffold, CI, and test wiring are in place.

## What's in
- Prerequisites (Android Studio Ladybug 2024.2.1+, JDK 17, Spotify dev app).
- Getting started: clone → open in Android Studio → first sync generates the Gradle wrapper → set `SPOTIFY_CLIENT_ID` in `local.properties`.
- Running on an emulator (Device Manager → Pixel 7 + API 35 Google APIs → Run).
- Running on a physical device (enable USB debugging → plug in → Run).
- Running tests from Android Studio and from the command line; summary table of the useful Gradle tasks.
- Note that `build` is a required status check on `main`.