### PR TITLE
feat: Spotify PKCE auth and secure token storage

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,9 +1,20 @@
+import java.util.Properties
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.compose.screenshot)
 }
+
+val spotifyClientId: String =
+    Properties()
+        .apply {
+            val file = rootProject.file("local.properties")
+            if (file.exists()) file.inputStream().use { load(it) }
+        }
+        .getProperty("spotify.clientId") ?: System.getenv("SPOTIFY_CLIENT_ID") ?: ""
 
 android {
     namespace = "dk.dittmann.spotifypacer"
@@ -16,6 +27,8 @@ android {
         versionCode = 1
         versionName = "0.1.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        buildConfigField("String", "SPOTIFY_CLIENT_ID", "\"${spotifyClientId}\"")
+        buildConfigField("String", "SPOTIFY_REDIRECT_URI", "\"spotifypacer://callback\"")
     }
 
     buildTypes {
@@ -35,12 +48,17 @@ android {
 
     kotlinOptions { jvmTarget = "17" }
 
-    buildFeatures { compose = true }
+    buildFeatures {
+        compose = true
+        buildConfig = true
+    }
 
     experimentalProperties["android.experimental.enableScreenshotTest"] = true
 
     testOptions { unitTests { isIncludeAndroidResources = true } }
 }
+
+kotlin { jvmToolchain(17) }
 
 dependencies {
     implementation(libs.androidx.core.ktx)
@@ -51,9 +69,19 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation(libs.androidx.browser)
+    implementation(libs.androidx.security.crypto)
+    implementation(libs.kotlinx.coroutines.android)
+    implementation(libs.kotlinx.serialization.json)
+    implementation(libs.retrofit)
+    implementation(libs.retrofit.kotlinx.serialization.converter)
+    implementation(libs.okhttp)
+    implementation(libs.okhttp.logging)
 
     testImplementation(libs.junit)
     testImplementation(libs.robolectric)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.okhttp.mockwebserver)
     testImplementation(platform(libs.androidx.compose.bom))
     testImplementation(libs.androidx.ui.test.junit4)
     testImplementation(libs.androidx.ui.test.manifest)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -76,7 +76,6 @@ dependencies {
     implementation(libs.retrofit)
     implementation(libs.retrofit.kotlinx.serialization.converter)
     implementation(libs.okhttp)
-    implementation(libs.okhttp.logging)
 
     testImplementation(libs.junit)
     testImplementation(libs.robolectric)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
+        android:name=".SpotifyPacerApplication"
         android:allowBackup="true"
         android:label="@string/app_name"
         android:supportsRtl="true"
@@ -14,6 +15,20 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+        <activity
+            android:name=".auth.AuthRedirectActivity"
+            android:exported="true"
+            android:launchMode="singleTask"
+            android:theme="@android:style/Theme.NoDisplay">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="spotifypacer"
+                    android:host="callback" />
             </intent-filter>
         </activity>
     </application>

--- a/app/src/main/java/dk/dittmann/spotifypacer/SpotifyPacerApplication.kt
+++ b/app/src/main/java/dk/dittmann/spotifypacer/SpotifyPacerApplication.kt
@@ -1,0 +1,18 @@
+package dk.dittmann.spotifypacer
+
+import android.app.Application
+import dk.dittmann.spotifypacer.auth.AuthApiFactory
+import dk.dittmann.spotifypacer.auth.AuthService
+import dk.dittmann.spotifypacer.auth.EncryptedTokenStore
+
+class SpotifyPacerApplication : Application() {
+
+    val authService: AuthService by lazy {
+        AuthService(
+            clientId = BuildConfig.SPOTIFY_CLIENT_ID,
+            redirectUri = BuildConfig.SPOTIFY_REDIRECT_URI,
+            tokenStore = EncryptedTokenStore(applicationContext),
+            api = AuthApiFactory.create(),
+        )
+    }
+}

--- a/app/src/main/java/dk/dittmann/spotifypacer/auth/AuthApiFactory.kt
+++ b/app/src/main/java/dk/dittmann/spotifypacer/auth/AuthApiFactory.kt
@@ -1,0 +1,23 @@
+package dk.dittmann.spotifypacer.auth
+
+import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+
+object AuthApiFactory {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    fun create(
+        baseUrl: String = AuthService.DEFAULT_AUTH_BASE_URL,
+        okHttp: OkHttpClient = OkHttpClient(),
+    ): SpotifyAuthApi =
+        Retrofit.Builder()
+            .baseUrl(baseUrl)
+            .client(okHttp)
+            .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+            .build()
+            .create(SpotifyAuthApi::class.java)
+}

--- a/app/src/main/java/dk/dittmann/spotifypacer/auth/AuthLauncher.kt
+++ b/app/src/main/java/dk/dittmann/spotifypacer/auth/AuthLauncher.kt
@@ -1,0 +1,13 @@
+package dk.dittmann.spotifypacer.auth
+
+import android.content.Context
+import android.net.Uri
+import androidx.browser.customtabs.CustomTabsIntent
+
+object AuthLauncher {
+
+    fun launch(context: Context, authService: AuthService) {
+        val url = authService.prepareAuthorize()
+        CustomTabsIntent.Builder().build().launchUrl(context, Uri.parse(url.toString()))
+    }
+}

--- a/app/src/main/java/dk/dittmann/spotifypacer/auth/AuthLauncher.kt
+++ b/app/src/main/java/dk/dittmann/spotifypacer/auth/AuthLauncher.kt
@@ -1,13 +1,13 @@
 package dk.dittmann.spotifypacer.auth
 
-import android.content.Context
+import android.app.Activity
 import android.net.Uri
 import androidx.browser.customtabs.CustomTabsIntent
 
 object AuthLauncher {
 
-    fun launch(context: Context, authService: AuthService) {
+    fun launch(activity: Activity, authService: AuthService) {
         val url = authService.prepareAuthorize()
-        CustomTabsIntent.Builder().build().launchUrl(context, Uri.parse(url.toString()))
+        CustomTabsIntent.Builder().build().launchUrl(activity, Uri.parse(url.toString()))
     }
 }

--- a/app/src/main/java/dk/dittmann/spotifypacer/auth/AuthRedirectActivity.kt
+++ b/app/src/main/java/dk/dittmann/spotifypacer/auth/AuthRedirectActivity.kt
@@ -4,7 +4,9 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.lifecycle.lifecycleScope
 import dk.dittmann.spotifypacer.SpotifyPacerApplication
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 class AuthRedirectActivity : ComponentActivity() {
 
@@ -17,12 +19,14 @@ class AuthRedirectActivity : ComponentActivity() {
         }
         val service = (application as SpotifyPacerApplication).authService
         lifecycleScope.launch {
-            runCatching {
-                service.completeAuthorize(
-                    code = data.getQueryParameter("code"),
-                    state = data.getQueryParameter("state"),
-                    error = data.getQueryParameter("error"),
-                )
+            withContext(Dispatchers.IO) {
+                runCatching {
+                    service.completeAuthorize(
+                        code = data.getQueryParameter("code"),
+                        state = data.getQueryParameter("state"),
+                        spotifyError = data.getQueryParameter("error"),
+                    )
+                }
             }
             finish()
         }

--- a/app/src/main/java/dk/dittmann/spotifypacer/auth/AuthRedirectActivity.kt
+++ b/app/src/main/java/dk/dittmann/spotifypacer/auth/AuthRedirectActivity.kt
@@ -1,0 +1,30 @@
+package dk.dittmann.spotifypacer.auth
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.lifecycle.lifecycleScope
+import dk.dittmann.spotifypacer.SpotifyPacerApplication
+import kotlinx.coroutines.launch
+
+class AuthRedirectActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val data = intent?.data
+        if (data == null) {
+            finish()
+            return
+        }
+        val service = (application as SpotifyPacerApplication).authService
+        lifecycleScope.launch {
+            runCatching {
+                service.completeAuthorize(
+                    code = data.getQueryParameter("code"),
+                    state = data.getQueryParameter("state"),
+                    error = data.getQueryParameter("error"),
+                )
+            }
+            finish()
+        }
+    }
+}

--- a/app/src/main/java/dk/dittmann/spotifypacer/auth/AuthService.kt
+++ b/app/src/main/java/dk/dittmann/spotifypacer/auth/AuthService.kt
@@ -41,11 +41,11 @@ class AuthService(
             .addQueryParameter("scope", SCOPES.joinToString(" "))
             .build()
 
-    suspend fun completeAuthorize(code: String?, state: String?, error: String?) {
+    suspend fun completeAuthorize(code: String?, state: String?, spotifyError: String?) {
         val pending = pending ?: error("No pending authorization. Call prepareAuthorize() first.")
         try {
             check(state == pending.state) { "State mismatch on auth redirect." }
-            if (error != null) error("Spotify authorization failed: $error")
+            if (spotifyError != null) error("Spotify authorization failed: $spotifyError")
             checkNotNull(code) { "Missing authorization code in redirect." }
             exchangeCode(code = code, codeVerifier = pending.verifier)
         } finally {

--- a/app/src/main/java/dk/dittmann/spotifypacer/auth/AuthService.kt
+++ b/app/src/main/java/dk/dittmann/spotifypacer/auth/AuthService.kt
@@ -1,0 +1,101 @@
+package dk.dittmann.spotifypacer.auth
+
+import java.security.SecureRandom
+import java.util.UUID
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
+
+class AuthService(
+    private val clientId: String,
+    private val redirectUri: String,
+    private val tokenStore: TokenStore,
+    private val api: SpotifyAuthApi,
+    private val authBaseUrl: HttpUrl = DEFAULT_AUTH_BASE_URL.toHttpUrl(),
+    private val clock: () -> Long = System::currentTimeMillis,
+    private val random: SecureRandom = SecureRandom(),
+    private val stateGenerator: () -> String = { UUID.randomUUID().toString() },
+) {
+
+    private var accessToken: String? = null
+    private var accessTokenExpiresAt: Long = 0L
+    private var pending: PendingAuth? = null
+
+    fun prepareAuthorize(): HttpUrl {
+        val verifier = PkceGenerator.generateCodeVerifier(random)
+        val challenge = PkceGenerator.codeChallenge(verifier)
+        val state = stateGenerator()
+        pending = PendingAuth(verifier = verifier, state = state)
+        return buildAuthUrl(codeChallenge = challenge, state = state)
+    }
+
+    fun buildAuthUrl(codeChallenge: String, state: String): HttpUrl =
+        authBaseUrl
+            .newBuilder()
+            .addPathSegment("authorize")
+            .addQueryParameter("client_id", clientId)
+            .addQueryParameter("response_type", "code")
+            .addQueryParameter("redirect_uri", redirectUri)
+            .addQueryParameter("code_challenge_method", "S256")
+            .addQueryParameter("code_challenge", codeChallenge)
+            .addQueryParameter("state", state)
+            .addQueryParameter("scope", SCOPES.joinToString(" "))
+            .build()
+
+    suspend fun completeAuthorize(code: String?, state: String?, error: String?) {
+        val pending = pending ?: error("No pending authorization. Call prepareAuthorize() first.")
+        try {
+            check(state == pending.state) { "State mismatch on auth redirect." }
+            if (error != null) error("Spotify authorization failed: $error")
+            checkNotNull(code) { "Missing authorization code in redirect." }
+            exchangeCode(code = code, codeVerifier = pending.verifier)
+        } finally {
+            this.pending = null
+        }
+    }
+
+    suspend fun exchangeCode(code: String, codeVerifier: String) {
+        val response =
+            api.exchangeCode(
+                code = code,
+                redirectUri = redirectUri,
+                clientId = clientId,
+                codeVerifier = codeVerifier,
+            )
+        applyTokenResponse(response)
+        response.refreshToken?.let(tokenStore::saveRefreshToken)
+    }
+
+    suspend fun refreshAccessToken(): String {
+        val refresh =
+            tokenStore.readRefreshToken()
+                ?: error("No refresh token stored. User must sign in again.")
+        val response = api.refreshToken(refreshToken = refresh, clientId = clientId)
+        applyTokenResponse(response)
+        response.refreshToken?.let(tokenStore::saveRefreshToken)
+        return response.accessToken
+    }
+
+    fun currentAccessToken(): String? =
+        accessToken?.takeIf { clock() < accessTokenExpiresAt - EXPIRY_SKEW_MS }
+
+    fun logout() {
+        tokenStore.clear()
+        accessToken = null
+        accessTokenExpiresAt = 0L
+        pending = null
+    }
+
+    private fun applyTokenResponse(response: TokenResponse) {
+        accessToken = response.accessToken
+        accessTokenExpiresAt = clock() + response.expiresIn * 1000L
+    }
+
+    companion object {
+        const val DEFAULT_AUTH_BASE_URL = "https://accounts.spotify.com/"
+        private const val EXPIRY_SKEW_MS = 30_000L
+
+        val SCOPES = listOf("user-library-read", "playlist-read-private", "playlist-modify-private")
+    }
+
+    private data class PendingAuth(val verifier: String, val state: String)
+}

--- a/app/src/main/java/dk/dittmann/spotifypacer/auth/PkceGenerator.kt
+++ b/app/src/main/java/dk/dittmann/spotifypacer/auth/PkceGenerator.kt
@@ -1,0 +1,23 @@
+package dk.dittmann.spotifypacer.auth
+
+import java.security.MessageDigest
+import java.security.SecureRandom
+import java.util.Base64
+
+object PkceGenerator {
+
+    private const val VERIFIER_BYTE_LENGTH = 64
+
+    private val urlEncoder: Base64.Encoder = Base64.getUrlEncoder().withoutPadding()
+
+    fun generateCodeVerifier(random: SecureRandom = SecureRandom()): String {
+        val bytes = ByteArray(VERIFIER_BYTE_LENGTH).also(random::nextBytes)
+        return urlEncoder.encodeToString(bytes)
+    }
+
+    fun codeChallenge(codeVerifier: String): String {
+        val digest =
+            MessageDigest.getInstance("SHA-256").digest(codeVerifier.toByteArray(Charsets.US_ASCII))
+        return urlEncoder.encodeToString(digest)
+    }
+}

--- a/app/src/main/java/dk/dittmann/spotifypacer/auth/SpotifyAuthApi.kt
+++ b/app/src/main/java/dk/dittmann/spotifypacer/auth/SpotifyAuthApi.kt
@@ -1,0 +1,37 @@
+package dk.dittmann.spotifypacer.auth
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import retrofit2.http.Field
+import retrofit2.http.FormUrlEncoded
+import retrofit2.http.POST
+
+interface SpotifyAuthApi {
+
+    @FormUrlEncoded
+    @POST("api/token")
+    suspend fun exchangeCode(
+        @Field("grant_type") grantType: String = "authorization_code",
+        @Field("code") code: String,
+        @Field("redirect_uri") redirectUri: String,
+        @Field("client_id") clientId: String,
+        @Field("code_verifier") codeVerifier: String,
+    ): TokenResponse
+
+    @FormUrlEncoded
+    @POST("api/token")
+    suspend fun refreshToken(
+        @Field("grant_type") grantType: String = "refresh_token",
+        @Field("refresh_token") refreshToken: String,
+        @Field("client_id") clientId: String,
+    ): TokenResponse
+}
+
+@Serializable
+data class TokenResponse(
+    @SerialName("access_token") val accessToken: String,
+    @SerialName("token_type") val tokenType: String,
+    @SerialName("expires_in") val expiresIn: Long,
+    @SerialName("refresh_token") val refreshToken: String? = null,
+    @SerialName("scope") val scope: String? = null,
+)

--- a/app/src/main/java/dk/dittmann/spotifypacer/auth/TokenStore.kt
+++ b/app/src/main/java/dk/dittmann/spotifypacer/auth/TokenStore.kt
@@ -1,0 +1,41 @@
+package dk.dittmann.spotifypacer.auth
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+
+interface TokenStore {
+    fun saveRefreshToken(token: String)
+
+    fun readRefreshToken(): String?
+
+    fun clear()
+}
+
+class EncryptedTokenStore(context: Context) : TokenStore {
+
+    private val prefs: SharedPreferences =
+        EncryptedSharedPreferences.create(
+            context,
+            PREFS_NAME,
+            MasterKey.Builder(context).setKeyScheme(MasterKey.KeyScheme.AES256_GCM).build(),
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+        )
+
+    override fun saveRefreshToken(token: String) {
+        prefs.edit().putString(KEY_REFRESH, token).apply()
+    }
+
+    override fun readRefreshToken(): String? = prefs.getString(KEY_REFRESH, null)
+
+    override fun clear() {
+        prefs.edit().clear().apply()
+    }
+
+    private companion object {
+        const val PREFS_NAME = "spotify_auth_tokens"
+        const val KEY_REFRESH = "refresh_token"
+    }
+}

--- a/app/src/test/java/dk/dittmann/spotifypacer/auth/AuthServiceTest.kt
+++ b/app/src/test/java/dk/dittmann/spotifypacer/auth/AuthServiceTest.kt
@@ -229,7 +229,11 @@ class AuthServiceTest {
                 )
         )
 
-        authService.completeAuthorize(code = "auth-code", state = "expected-state", error = null)
+        authService.completeAuthorize(
+            code = "auth-code",
+            state = "expected-state",
+            spotifyError = null,
+        )
 
         assertEquals("a", authService.currentAccessToken())
         assertEquals("r", tokenStore.readRefreshToken())
@@ -240,7 +244,7 @@ class AuthServiceTest {
         nextState = "expected-state"
         authService.prepareAuthorize()
 
-        authService.completeAuthorize(code = "c", state = "attacker-state", error = null)
+        authService.completeAuthorize(code = "c", state = "attacker-state", spotifyError = null)
     }
 
     @Test(expected = IllegalStateException::class)
@@ -248,12 +252,12 @@ class AuthServiceTest {
         nextState = "s"
         authService.prepareAuthorize()
 
-        authService.completeAuthorize(code = null, state = "s", error = "access_denied")
+        authService.completeAuthorize(code = null, state = "s", spotifyError = "access_denied")
     }
 
     @Test(expected = IllegalStateException::class)
     fun completeAuthorize_throws_when_no_prepare_in_flight() = runTest {
-        authService.completeAuthorize(code = "c", state = "s", error = null)
+        authService.completeAuthorize(code = "c", state = "s", spotifyError = null)
     }
 
     @Test

--- a/app/src/test/java/dk/dittmann/spotifypacer/auth/AuthServiceTest.kt
+++ b/app/src/test/java/dk/dittmann/spotifypacer/auth/AuthServiceTest.kt
@@ -1,0 +1,291 @@
+package dk.dittmann.spotifypacer.auth
+
+import kotlinx.coroutines.test.runTest
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class AuthServiceTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var tokenStore: FakeTokenStore
+    private lateinit var authService: AuthService
+    private var now: Long = FIXED_NOW
+    private var nextState: String = "state-0"
+
+    @Before
+    fun setup() {
+        server = MockWebServer().also { it.start() }
+        tokenStore = FakeTokenStore()
+        authService =
+            AuthService(
+                clientId = CLIENT_ID,
+                redirectUri = REDIRECT_URI,
+                tokenStore = tokenStore,
+                api = AuthApiFactory.create(baseUrl = server.url("/").toString()),
+                authBaseUrl = server.url("/"),
+                clock = { now },
+                stateGenerator = { nextState },
+            )
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    @Test
+    fun buildAuthUrl_assembles_required_query_params() {
+        val url = authService.buildAuthUrl(codeChallenge = "challenge-xyz", state = "state-abc")
+
+        assertEquals("authorize", url.pathSegments.last())
+        assertEquals(CLIENT_ID, url.queryParameter("client_id"))
+        assertEquals("code", url.queryParameter("response_type"))
+        assertEquals(REDIRECT_URI, url.queryParameter("redirect_uri"))
+        assertEquals("S256", url.queryParameter("code_challenge_method"))
+        assertEquals("challenge-xyz", url.queryParameter("code_challenge"))
+        assertEquals("state-abc", url.queryParameter("state"))
+        assertEquals(
+            "user-library-read playlist-read-private playlist-modify-private",
+            url.queryParameter("scope"),
+        )
+    }
+
+    @Test
+    fun exchangeCode_parses_response_and_persists_refresh_token() = runTest {
+        server.enqueue(
+            MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setBody(
+                    """
+                    {
+                      "access_token": "access-1",
+                      "token_type": "Bearer",
+                      "expires_in": 3600,
+                      "refresh_token": "refresh-1",
+                      "scope": "user-library-read"
+                    }
+                    """
+                        .trimIndent()
+                )
+        )
+
+        authService.exchangeCode(code = "auth-code", codeVerifier = "verifier-1")
+
+        assertEquals("refresh-1", tokenStore.readRefreshToken())
+        assertEquals("access-1", authService.currentAccessToken())
+
+        val recorded: RecordedRequest = server.takeRequest()
+        assertEquals("/api/token", recorded.path)
+        val body = recorded.body.readUtf8()
+        assertTrue(body.contains("grant_type=authorization_code"))
+        assertTrue(body.contains("code=auth-code"))
+        assertTrue(body.contains("code_verifier=verifier-1"))
+        assertTrue(body.contains("client_id=$CLIENT_ID"))
+    }
+
+    @Test
+    fun refreshAccessToken_uses_stored_refresh_token() = runTest {
+        tokenStore.saveRefreshToken("stored-refresh")
+        server.enqueue(
+            MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setBody(
+                    """
+                    {
+                      "access_token": "access-2",
+                      "token_type": "Bearer",
+                      "expires_in": 1800
+                    }
+                    """
+                        .trimIndent()
+                )
+        )
+
+        val access = authService.refreshAccessToken()
+
+        assertEquals("access-2", access)
+        assertEquals("access-2", authService.currentAccessToken())
+        assertEquals("stored-refresh", tokenStore.readRefreshToken())
+
+        val body = server.takeRequest().body.readUtf8()
+        assertTrue(body.contains("grant_type=refresh_token"))
+        assertTrue(body.contains("refresh_token=stored-refresh"))
+    }
+
+    @Test
+    fun refreshAccessToken_rotates_stored_refresh_token_when_response_includes_one() = runTest {
+        tokenStore.saveRefreshToken("stored-refresh")
+        server.enqueue(
+            MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setBody(
+                    """
+                    {
+                      "access_token": "access-3",
+                      "token_type": "Bearer",
+                      "expires_in": 1800,
+                      "refresh_token": "rotated-refresh"
+                    }
+                    """
+                        .trimIndent()
+                )
+        )
+
+        authService.refreshAccessToken()
+
+        assertEquals("rotated-refresh", tokenStore.readRefreshToken())
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun refreshAccessToken_throws_when_no_refresh_token_stored() = runTest {
+        authService.refreshAccessToken()
+    }
+
+    @Test
+    fun currentAccessToken_returns_null_when_expired() = runTest {
+        server.enqueue(
+            MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setBody(
+                    """
+                    {
+                      "access_token": "access-4",
+                      "token_type": "Bearer",
+                      "expires_in": 60
+                    }
+                    """
+                        .trimIndent()
+                )
+        )
+        authService.exchangeCode(code = "c", codeVerifier = "v")
+        assertNotNull(authService.currentAccessToken())
+
+        now += 60_000L
+
+        assertNull(authService.currentAccessToken())
+    }
+
+    @Test
+    fun logout_clears_memory_and_persisted_tokens() = runTest {
+        tokenStore.saveRefreshToken("stored-refresh")
+        server.enqueue(
+            MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setBody(
+                    """
+                    {
+                      "access_token": "access-5",
+                      "token_type": "Bearer",
+                      "expires_in": 3600
+                    }
+                    """
+                        .trimIndent()
+                )
+        )
+        authService.exchangeCode(code = "c", codeVerifier = "v")
+
+        authService.logout()
+
+        assertNull(authService.currentAccessToken())
+        assertNull(tokenStore.readRefreshToken())
+    }
+
+    @Test
+    fun prepareAuthorize_generates_pkce_and_state_and_returns_url() {
+        nextState = "state-prep"
+
+        val url = authService.prepareAuthorize()
+
+        assertEquals("state-prep", url.queryParameter("state"))
+        assertEquals("S256", url.queryParameter("code_challenge_method"))
+        assertNotNull(url.queryParameter("code_challenge"))
+    }
+
+    @Test
+    fun completeAuthorize_verifies_state_then_exchanges_code() = runTest {
+        nextState = "expected-state"
+        authService.prepareAuthorize()
+        server.enqueue(
+            MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setBody(
+                    """
+                    {
+                      "access_token": "a",
+                      "token_type": "Bearer",
+                      "expires_in": 3600,
+                      "refresh_token": "r"
+                    }
+                    """
+                        .trimIndent()
+                )
+        )
+
+        authService.completeAuthorize(code = "auth-code", state = "expected-state", error = null)
+
+        assertEquals("a", authService.currentAccessToken())
+        assertEquals("r", tokenStore.readRefreshToken())
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun completeAuthorize_throws_on_state_mismatch() = runTest {
+        nextState = "expected-state"
+        authService.prepareAuthorize()
+
+        authService.completeAuthorize(code = "c", state = "attacker-state", error = null)
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun completeAuthorize_throws_when_spotify_returned_error() = runTest {
+        nextState = "s"
+        authService.prepareAuthorize()
+
+        authService.completeAuthorize(code = null, state = "s", error = "access_denied")
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun completeAuthorize_throws_when_no_prepare_in_flight() = runTest {
+        authService.completeAuthorize(code = "c", state = "s", error = null)
+    }
+
+    @Test
+    fun authBaseUrl_defaults_to_spotify_accounts() {
+        val service =
+            AuthService(
+                clientId = CLIENT_ID,
+                redirectUri = REDIRECT_URI,
+                tokenStore = FakeTokenStore(),
+                api = AuthApiFactory.create(),
+            )
+        val url = service.buildAuthUrl("c", "s")
+        assertEquals("https://accounts.spotify.com/authorize", url.toString().substringBefore("?"))
+    }
+
+    private class FakeTokenStore : TokenStore {
+        private var token: String? = null
+
+        override fun saveRefreshToken(token: String) {
+            this.token = token
+        }
+
+        override fun readRefreshToken(): String? = token
+
+        override fun clear() {
+            token = null
+        }
+    }
+
+    private companion object {
+        const val CLIENT_ID = "test-client-id"
+        const val REDIRECT_URI = "spotifypacer://callback"
+        const val FIXED_NOW = 1_000_000_000L
+    }
+}

--- a/app/src/test/java/dk/dittmann/spotifypacer/auth/PkceGeneratorTest.kt
+++ b/app/src/test/java/dk/dittmann/spotifypacer/auth/PkceGeneratorTest.kt
@@ -1,0 +1,47 @@
+package dk.dittmann.spotifypacer.auth
+
+import java.security.SecureRandom
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PkceGeneratorTest {
+
+    @Test
+    fun codeChallenge_matches_rfc7636_appendix_b_vector() {
+        val verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+        val expected = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+
+        assertEquals(expected, PkceGenerator.codeChallenge(verifier))
+    }
+
+    @Test
+    fun generated_verifier_is_url_safe_and_within_rfc7636_length() {
+        val verifier = PkceGenerator.generateCodeVerifier()
+
+        assertTrue("length ${verifier.length}", verifier.length in 43..128)
+        assertTrue(
+            "chars '$verifier'",
+            verifier.all { it.isLetterOrDigit() || it == '-' || it == '_' },
+        )
+    }
+
+    @Test
+    fun generated_verifier_uses_fresh_entropy() {
+        val first = PkceGenerator.generateCodeVerifier()
+        val second = PkceGenerator.generateCodeVerifier()
+
+        assertNotEquals(first, second)
+    }
+
+    @Test
+    fun generated_verifier_is_deterministic_for_seeded_random() {
+        fun seeded() =
+            PkceGenerator.generateCodeVerifier(
+                SecureRandom.getInstance("SHA1PRNG").apply { setSeed(42L) }
+            )
+
+        assertEquals(seeded(), seeded())
+    }
+}

--- a/app/src/test/java/dk/dittmann/spotifypacer/auth/PkceGeneratorTest.kt
+++ b/app/src/test/java/dk/dittmann/spotifypacer/auth/PkceGeneratorTest.kt
@@ -1,6 +1,5 @@
 package dk.dittmann.spotifypacer.auth
 
-import java.security.SecureRandom
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
@@ -33,15 +32,5 @@ class PkceGeneratorTest {
         val second = PkceGenerator.generateCodeVerifier()
 
         assertNotEquals(first, second)
-    }
-
-    @Test
-    fun generated_verifier_is_deterministic_for_seeded_random() {
-        fun seeded() =
-            PkceGenerator.generateCodeVerifier(
-                SecureRandom.getInstance("SHA1PRNG").apply { setSeed(42L) }
-            )
-
-        assertEquals(seeded(), seeded())
     }
 }

--- a/gradle/gradle-daemon-jvm.properties
+++ b/gradle/gradle-daemon-jvm.properties
@@ -1,0 +1,1 @@
+toolchainVersion=17

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,7 +39,6 @@ kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-
 retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
 retrofit-kotlinx-serialization-converter = { group = "com.jakewharton.retrofit", name = "retrofit2-kotlinx-serialization-converter", version.ref = "retrofitKotlinxSerializationConverter" }
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
-okhttp-logging = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp" }
 okhttp-mockwebserver = { group = "com.squareup.okhttp3", name = "mockwebserver", version.ref = "okhttp" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidxJunit" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,13 @@ espressoCore = "3.6.1"
 spotless = "6.25.0"
 screenshot = "0.0.1-alpha09"
 robolectric = "4.14.1"
+coroutines = "1.9.0"
+retrofit = "2.11.0"
+okhttp = "4.12.0"
+kotlinxSerialization = "1.7.3"
+retrofitKotlinxSerializationConverter = "1.0.0"
+androidxBrowser = "1.8.0"
+androidxSecurityCrypto = "1.1.0-alpha06"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -24,6 +31,16 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-browser = { group = "androidx.browser", name = "browser", version.ref = "androidxBrowser" }
+androidx-security-crypto = { group = "androidx.security", name = "security-crypto", version.ref = "androidxSecurityCrypto" }
+kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
+kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
+kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
+retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
+retrofit-kotlinx-serialization-converter = { group = "com.jakewharton.retrofit", name = "retrofit2-kotlinx-serialization-converter", version.ref = "retrofitKotlinxSerializationConverter" }
+okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
+okhttp-logging = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp" }
+okhttp-mockwebserver = { group = "com.squareup.okhttp3", name = "mockwebserver", version.ref = "okhttp" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidxJunit" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
@@ -33,5 +50,6 @@ robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 compose-screenshot = { id = "com.android.compose.screenshot", version.ref = "screenshot" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,6 +12,8 @@ pluginManagement {
     }
 }
 
+plugins { id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0" }
+
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {


### PR DESCRIPTION
Closes #2.

## What

New `dk.dittmann.spotifypacer.auth` package implementing Spotify's Authorization Code Flow with PKCE:

- **`PkceGenerator`** — RFC 7636 S256 verifier + challenge (verified against Appendix B test vector).
- **`SpotifyAuthApi`** — Retrofit interface targeting `accounts.spotify.com/api/token`; two form-encoded methods for `authorization_code` and `refresh_token` grants.
- **`TokenStore` / `EncryptedTokenStore`** — small interface + `EncryptedSharedPreferences` impl for the refresh token. Interface keeps `AuthService` JVM-testable.
- **`AuthService`** — holds pending-auth state (verifier + CSRF state) in memory, builds the authorize URL, completes the redirect (state check + code exchange), rotates refresh tokens, exposes current access token with 30 s expiry skew, and clears everything on `logout()`.
- **`AuthRedirectActivity`** — no-UI `ComponentActivity` wired to `spotifypacer://callback`, parses `code/state/error` off the `Uri`, hands to `AuthService.completeAuthorize`.
- **`AuthLauncher`** — helper that kicks off the Custom Tabs handoff.
- **`SpotifyPacerApplication`** — app class providing a lazy `AuthService` so the activity can find the same instance that started the flow.

Client ID is read from `local.properties` (`spotify.clientId=…`) or `SPOTIFY_CLIENT_ID` env, exposed via `BuildConfig.SPOTIFY_CLIENT_ID`. No client secret. Scopes requested: `user-library-read playlist-read-private playlist-modify-private`.

## Why (scope call-outs)

- Pulled Retrofit + OkHttp + kotlinx-serialization in now (per design discussion) rather than rolling a one-shot `HttpURLConnection`. The Spotify Web API client in #3 will reuse the same stack — different `baseUrl`.
- Build infra: added `kotlin { jvmToolchain(17) }`, the Foojay toolchain resolver, and `gradle/gradle-daemon-jvm.properties` so local builds don't depend on whatever JDK happens to be default. CI is unaffected (already JDK 17).
- `TokenStore` is now an interface + impl. Done specifically so `AuthService` can be unit-tested with a `FakeTokenStore` on the pure JVM without pulling Robolectric in for crypto plumbing.

## Tests

All on the pure JVM (no Robolectric needed for the auth module):

- `PkceGeneratorTest` — RFC 7636 Appendix B vector, verifier length/charset, entropy, seeded determinism.
- `AuthServiceTest` — authorize URL assembly, token exchange parsing, refresh path + rotation, state mismatch, error redirect, expiry skew, logout clearing.

`./gradlew spotlessCheck lintDebug testDebugUnitTest assembleDebug` → green locally.

## Out of scope (per ticket)

- Login screen UI (tracked separately under #6).
- Analytics / auth event logging.