### PR TITLE
docs: reflect current state after auth + pacing landed

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Pre-alpha, headless. The non-UI pieces of the MVP are in place; the Compose scre
 - ✅ Spotify **PKCE auth** + encrypted refresh-token storage ([#2](https://github.com/sebastiankdittmann/spotify-pacer/issues/2))
 - ✅ **Pace curve** generator — constant, linear, delayed-exponential ([#4](https://github.com/sebastiankdittmann/spotify-pacer/issues/4))
 - ✅ **Track selector** — greedy minute-by-minute match with half/double-tempo substitution and widening tolerance ([#5](https://github.com/sebastiankdittmann/spotify-pacer/issues/5))
-- ⏳ Spotify **Web API** client — search, audio-features, playlists ([#3](https://github.com/sebastiankdittmann/spotify-pacer/issues/3))
+- ⏳ Spotify **Web API** client — `/me`, liked tracks, audio-features, playlist create/add ([#3](https://github.com/sebastiankdittmann/spotify-pacer/issues/3))
 - ⏳ **UI screens** — login, run setup, preview ([#6](https://github.com/sebastiankdittmann/spotify-pacer/issues/6), [#7](https://github.com/sebastiankdittmann/spotify-pacer/issues/7), [#8](https://github.com/sebastiankdittmann/spotify-pacer/issues/8))
 - ⏳ Save playlist to account ([#9](https://github.com/sebastiankdittmann/spotify-pacer/issues/9))
 
@@ -57,7 +57,7 @@ All under `app/src/main/java/dk/dittmann/spotifypacer/`.
    ```
 2. Open the project folder in Android Studio.
 3. Wait for **Gradle Sync** to finish. First sync downloads AGP, Kotlin, Compose, and the Android SDK components. The Gradle wrapper is pinned to 8.11.1 and committed.
-4. Create `local.properties` in the project root with your Spotify client ID:
+4. Add your Spotify client ID to `local.properties` in the project root (create the file if it doesn't exist; keep any existing entries like `sdk.dir`):
    ```properties
    spotify.clientId=paste_your_public_client_id_here
    ```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,24 @@ Login uses Spotify's **Authorization Code Flow with PKCE** so the app acts on be
 
 ## Status
 
-Pre-alpha. Android project scaffolded, CI green, no feature code yet. Work tracked under the [v0.1 MVP milestone](https://github.com/sebastiankdittmann/spotify-pacer/milestones).
+Pre-alpha, headless. The non-UI pieces of the MVP are in place; the Compose screens that wire them together are next. Work tracked under the [v0.1 MVP milestone](https://github.com/sebastiankdittmann/spotify-pacer/milestones).
+
+- ✅ Spotify **PKCE auth** + encrypted refresh-token storage ([#2](https://github.com/sebastiankdittmann/spotify-pacer/issues/2))
+- ✅ **Pace curve** generator — constant, linear, delayed-exponential ([#4](https://github.com/sebastiankdittmann/spotify-pacer/issues/4))
+- ✅ **Track selector** — greedy minute-by-minute match with half/double-tempo substitution and widening tolerance ([#5](https://github.com/sebastiankdittmann/spotify-pacer/issues/5))
+- ⏳ Spotify **Web API** client — search, audio-features, playlists ([#3](https://github.com/sebastiankdittmann/spotify-pacer/issues/3))
+- ⏳ **UI screens** — login, run setup, preview ([#6](https://github.com/sebastiankdittmann/spotify-pacer/issues/6), [#7](https://github.com/sebastiankdittmann/spotify-pacer/issues/7), [#8](https://github.com/sebastiankdittmann/spotify-pacer/issues/8))
+- ⏳ Save playlist to account ([#9](https://github.com/sebastiankdittmann/spotify-pacer/issues/9))
+
+## Modules
+
+All under `app/src/main/java/dk/dittmann/spotifypacer/`.
+
+| Package | What's in it |
+|---|---|
+| `auth/` | `PkceGenerator`, `AuthService`, `SpotifyAuthApi` (Retrofit), `TokenStore` (+ `EncryptedTokenStore`), `AuthRedirectActivity`, `AuthLauncher` |
+| `pacing/` | `PaceStrategy`, `generateCurve(...)`, `TrackSelector` |
+| *(root)* | `SpotifyPacerApplication` (owns the lazy `AuthService`), `MainActivity` (placeholder) |
 
 ## Stack
 
@@ -29,7 +46,7 @@ Pre-alpha. Android project scaffolded, CI green, no feature code yet. Work track
 
 - **Android Studio Ladybug** (2024.2.1) or newer — needed for the Compose screenshot-test plugin. [Download](https://developer.android.com/studio).
 - **JDK 17** — bundled with Android Studio; Gradle uses it automatically.
-- A Spotify account (free works) plus a **Spotify Developer app** — register at <https://developer.spotify.com/dashboard> when you start on the auth issue. Redirect URI: `spotifypacer://callback`.
+- A Spotify account (free works) plus a **Spotify Developer app** — register at <https://developer.spotify.com/dashboard>. Redirect URI: `spotifypacer://callback`. The client ID goes in `local.properties` (see [Getting started](#getting-started)).
 
 ## Getting started
 
@@ -40,11 +57,11 @@ Pre-alpha. Android project scaffolded, CI green, no feature code yet. Work track
    ```
 2. Open the project folder in Android Studio.
 3. Wait for **Gradle Sync** to finish. First sync downloads AGP, Kotlin, Compose, and the Android SDK components. The Gradle wrapper is pinned to 8.11.1 and committed.
-4. When the auth code lands ([issue #2](https://github.com/sebastiankdittmann/spotify-pacer/issues/2)), create `local.properties` in the project root:
+4. Create `local.properties` in the project root with your Spotify client ID:
    ```properties
-   SPOTIFY_CLIENT_ID=paste_your_public_client_id_here
+   spotify.clientId=paste_your_public_client_id_here
    ```
-   `local.properties` is gitignored. There is no client secret — PKCE is used.
+   Register a Spotify Developer app at <https://developer.spotify.com/dashboard> with redirect URI `spotifypacer://callback`. `local.properties` is gitignored. There is no client secret — PKCE is used. The app reads `BuildConfig.SPOTIFY_CLIENT_ID` from this file (or the `SPOTIFY_CLIENT_ID` env var).
 
 ## Running the app
 

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -19,9 +19,9 @@ Generate a Spotify playlist whose track tempo (BPM) matches a user-selected paci
 ## Functional requirements
 
 ### Auth
-- **F-A1**: Use Spotify Authorization Code Flow with PKCE. The app must not require users to paste tokens or register their own app credentials.
-- **F-A2**: Store refresh token securely on device (EncryptedSharedPreferences or Android Keystore-backed).
-- **F-A3**: Sign-out clears stored tokens.
+- **F-A1** *(implemented, [#2](https://github.com/sebastiankdittmann/spotify-pacer/issues/2))*: Use Spotify Authorization Code Flow with PKCE. The app must not require users to paste tokens or register their own app credentials.
+- **F-A2** *(implemented, [#2](https://github.com/sebastiankdittmann/spotify-pacer/issues/2))*: Store refresh token securely on device (EncryptedSharedPreferences or Android Keystore-backed).
+- **F-A3** *(implemented, [#2](https://github.com/sebastiankdittmann/spotify-pacer/issues/2))*: Sign-out clears stored tokens.
 
 ### Input
 - **F-I1**: User inputs distance (km, with decimal) and target time (hh:mm:ss or mm:ss).
@@ -29,14 +29,14 @@ Generate a Spotify playlist whose track tempo (BPM) matches a user-selected paci
 - **F-I3**: Sensible validation: positive distance, positive time, resulting average pace in a plausible running range (warn outside 3:00–10:00 min/km).
 
 ### Pacing engine
-- **F-P1**: Convert (distance, time, strategy) into a BPM-over-time curve covering the full run duration.
+- **F-P1** *(implemented, [#4](https://github.com/sebastiankdittmann/spotify-pacer/issues/4))*: Convert (distance, time, strategy) into a BPM-over-time curve covering the full run duration.
 - **F-P2**: Total playlist duration should be within ±30 s of the target time.
-- **F-P3**: Strategy definitions in [DESIGN.md](DESIGN.md#pace-curves).
+- **F-P3** *(implemented, [#4](https://github.com/sebastiankdittmann/spotify-pacer/issues/4))*: Strategy definitions in [DESIGN.md](DESIGN.md#pace-curves).
 
 ### Track selection
 - **F-T1**: Source candidate tracks from the user's liked songs and playlists.
 - **F-T2**: Fetch `audio-features` for candidates to get `tempo` (BPM).
-- **F-T3**: Select tracks greedily, minute by minute, whose BPM best matches the curve at that moment, subject to:
+- **F-T3** *(implemented, [#5](https://github.com/sebastiankdittmann/spotify-pacer/issues/5))*: Select tracks greedily, minute by minute, whose BPM best matches the curve at that moment, subject to:
   - No repeats within a playlist.
   - Prefer tracks within ±3 BPM of the target at that point; widen tolerance if no match.
   - Allow half/double-tempo substitution (a 90 BPM track can stand in for 180 BPM and vice versa).


### PR DESCRIPTION
## Summary

- **README Status**: was "no feature code yet" — now lists what shipped (auth #2, pace curve #4, track selector #5) and what's still open (web API #3, UI #6–#8, save playlist #9).
- **README Modules**: small table pointing at `auth/`, `pacing/`, and the app root so new contributors can find their way around.
- **README Getting started**: the `local.properties` step was gated on "when the auth code lands" and used the wrong property name (`SPOTIFY_CLIENT_ID` instead of `spotify.clientId` as the build script actually reads). Fixed both.
- **REQUIREMENTS.md**: annotated each implemented requirement (F-A1/2/3, F-P1/3, F-T3) with an "(implemented, #N)" tag linking to the issue that closed it. Spec stays spec; just a breadcrumb to where it landed.

## Test plan

- [x] README renders — checked diff locally
- [x] No code changes, CI should be a no-op