### PR TITLE
feat: Spotify Web API client (Retrofit + DTOs)

### DIFF
--- a/app/src/main/java/dk/dittmann/spotifypacer/spotify/RateLimitInterceptor.kt
+++ b/app/src/main/java/dk/dittmann/spotifypacer/spotify/RateLimitInterceptor.kt
@@ -16,10 +16,12 @@ class RateLimitInterceptor(
         val response = chain.proceed(chain.request())
         if (response.code != 429) return response
 
-        val retryAfterSeconds = response.header("Retry-After")?.toLongOrNull() ?: 0L
-        val delayMs = (retryAfterSeconds * 1000L).coerceIn(0L, maxRetryDelayMs)
+        val retryAfterSeconds = response.header("Retry-After")?.toLongOrNull()
+        if (retryAfterSeconds == null || retryAfterSeconds <= 0L) return response
+
+        val delayMs = (retryAfterSeconds * 1000L).coerceAtMost(maxRetryDelayMs)
         response.close()
-        if (delayMs > 0L) sleeper(delayMs)
+        sleeper(delayMs)
         return chain.proceed(chain.request())
     }
 

--- a/app/src/main/java/dk/dittmann/spotifypacer/spotify/RateLimitInterceptor.kt
+++ b/app/src/main/java/dk/dittmann/spotifypacer/spotify/RateLimitInterceptor.kt
@@ -1,0 +1,29 @@
+package dk.dittmann.spotifypacer.spotify
+
+import okhttp3.Interceptor
+import okhttp3.Response
+
+/**
+ * On HTTP 429, sleeps for the duration suggested by the Retry-After header (seconds) and retries
+ * the request once. Subsequent 429s propagate to the caller.
+ */
+class RateLimitInterceptor(
+    private val sleeper: (Long) -> Unit = Thread::sleep,
+    private val maxRetryDelayMs: Long = DEFAULT_MAX_RETRY_DELAY_MS,
+) : Interceptor {
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val response = chain.proceed(chain.request())
+        if (response.code != 429) return response
+
+        val retryAfterSeconds = response.header("Retry-After")?.toLongOrNull() ?: 0L
+        val delayMs = (retryAfterSeconds * 1000L).coerceIn(0L, maxRetryDelayMs)
+        response.close()
+        if (delayMs > 0L) sleeper(delayMs)
+        return chain.proceed(chain.request())
+    }
+
+    private companion object {
+        const val DEFAULT_MAX_RETRY_DELAY_MS = 60_000L
+    }
+}

--- a/app/src/main/java/dk/dittmann/spotifypacer/spotify/SpotifyApi.kt
+++ b/app/src/main/java/dk/dittmann/spotifypacer/spotify/SpotifyApi.kt
@@ -1,0 +1,33 @@
+package dk.dittmann.spotifypacer.spotify
+
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+interface SpotifyApi {
+
+    @GET("v1/me") suspend fun me(): UserProfile
+
+    @GET("v1/me/tracks")
+    suspend fun savedTracks(
+        @Query("limit") limit: Int = 50,
+        @Query("offset") offset: Int = 0,
+    ): SavedTracksPage
+
+    @GET("v1/audio-features")
+    suspend fun audioFeatures(@Query("ids") ids: String): AudioFeaturesResponse
+
+    @POST("v1/users/{user_id}/playlists")
+    suspend fun createPlaylist(
+        @Path("user_id") userId: String,
+        @Body body: CreatePlaylistBody,
+    ): Playlist
+
+    @POST("v1/playlists/{playlist_id}/tracks")
+    suspend fun addTracks(
+        @Path("playlist_id") playlistId: String,
+        @Body body: AddTracksBody,
+    ): AddTracksResponse
+}

--- a/app/src/main/java/dk/dittmann/spotifypacer/spotify/SpotifyApiFactory.kt
+++ b/app/src/main/java/dk/dittmann/spotifypacer/spotify/SpotifyApiFactory.kt
@@ -1,0 +1,36 @@
+package dk.dittmann.spotifypacer.spotify
+
+import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+
+object SpotifyApiFactory {
+
+    const val DEFAULT_BASE_URL = "https://api.spotify.com/"
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        explicitNulls = false
+    }
+
+    fun create(
+        tokens: SpotifyTokenProvider,
+        baseUrl: String = DEFAULT_BASE_URL,
+        okHttp: OkHttpClient = OkHttpClient(),
+    ): SpotifyApi {
+        val client =
+            okHttp
+                .newBuilder()
+                .addInterceptor(SpotifyAuthInterceptor(tokens))
+                .addInterceptor(RateLimitInterceptor())
+                .build()
+        return Retrofit.Builder()
+            .baseUrl(baseUrl)
+            .client(client)
+            .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+            .build()
+            .create(SpotifyApi::class.java)
+    }
+}

--- a/app/src/main/java/dk/dittmann/spotifypacer/spotify/SpotifyAuthInterceptor.kt
+++ b/app/src/main/java/dk/dittmann/spotifypacer/spotify/SpotifyAuthInterceptor.kt
@@ -1,0 +1,26 @@
+package dk.dittmann.spotifypacer.spotify
+
+import okhttp3.Interceptor
+import okhttp3.Request
+import okhttp3.Response
+
+/**
+ * Attaches a Bearer access token to every request. If the response is 401, refreshes the token once
+ * and retries.
+ */
+class SpotifyAuthInterceptor(private val tokens: SpotifyTokenProvider) : Interceptor {
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val token = tokens.currentAccessToken() ?: tokens.refreshAccessToken()
+        val response = chain.proceed(chain.request().withBearer(token))
+
+        if (response.code != 401) return response
+
+        response.close()
+        val refreshed = tokens.refreshAccessToken()
+        return chain.proceed(chain.request().withBearer(refreshed))
+    }
+
+    private fun Request.withBearer(token: String): Request =
+        newBuilder().header("Authorization", "Bearer $token").build()
+}

--- a/app/src/main/java/dk/dittmann/spotifypacer/spotify/SpotifyClient.kt
+++ b/app/src/main/java/dk/dittmann/spotifypacer/spotify/SpotifyClient.kt
@@ -1,0 +1,49 @@
+package dk.dittmann.spotifypacer.spotify
+
+/**
+ * High-level facade over [SpotifyApi] that handles batching constraints (Spotify enforces 100-item
+ * limits on `audio-features` ids and `playlists/{id}/tracks` uris).
+ */
+class SpotifyClient(private val api: SpotifyApi) {
+
+    suspend fun me(): UserProfile = api.me()
+
+    suspend fun savedTracks(limit: Int = 50, offset: Int = 0): SavedTracksPage =
+        api.savedTracks(limit = limit, offset = offset)
+
+    /** Fetches audio features for any number of track ids in 100-id chunks. */
+    suspend fun audioFeatures(ids: List<String>): List<AudioFeatures?> {
+        if (ids.isEmpty()) return emptyList()
+        val results = mutableListOf<AudioFeatures?>()
+        ids.chunked(MAX_AUDIO_FEATURES_BATCH).forEach { chunk ->
+            results += api.audioFeatures(chunk.joinToString(",")).audioFeatures
+        }
+        return results
+    }
+
+    suspend fun createPlaylist(
+        userId: String,
+        name: String,
+        description: String? = null,
+        public: Boolean = false,
+    ): Playlist =
+        api.createPlaylist(
+            userId = userId,
+            body = CreatePlaylistBody(name = name, public = public, description = description),
+        )
+
+    /** Adds any number of track URIs to a playlist in 100-uri chunks. Returns each snapshot id. */
+    suspend fun addTracks(playlistId: String, uris: List<String>): List<String> {
+        if (uris.isEmpty()) return emptyList()
+        val snapshots = mutableListOf<String>()
+        uris.chunked(MAX_ADD_TRACKS_BATCH).forEach { chunk ->
+            snapshots += api.addTracks(playlistId, AddTracksBody(uris = chunk)).snapshotId
+        }
+        return snapshots
+    }
+
+    private companion object {
+        const val MAX_AUDIO_FEATURES_BATCH = 100
+        const val MAX_ADD_TRACKS_BATCH = 100
+    }
+}

--- a/app/src/main/java/dk/dittmann/spotifypacer/spotify/SpotifyDtos.kt
+++ b/app/src/main/java/dk/dittmann/spotifypacer/spotify/SpotifyDtos.kt
@@ -1,0 +1,74 @@
+package dk.dittmann.spotifypacer.spotify
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class UserProfile(
+    @SerialName("id") val id: String,
+    @SerialName("display_name") val displayName: String? = null,
+)
+
+@Serializable
+data class SavedTracksPage(
+    @SerialName("items") val items: List<SavedTrackItem>,
+    @SerialName("total") val total: Int,
+    @SerialName("limit") val limit: Int,
+    @SerialName("offset") val offset: Int,
+    @SerialName("next") val next: String? = null,
+)
+
+@Serializable
+data class SavedTrackItem(
+    @SerialName("added_at") val addedAt: String? = null,
+    @SerialName("track") val track: Track,
+)
+
+@Serializable
+data class Track(
+    @SerialName("id") val id: String,
+    @SerialName("uri") val uri: String,
+    @SerialName("name") val name: String,
+    @SerialName("duration_ms") val durationMs: Long,
+    @SerialName("artists") val artists: List<Artist> = emptyList(),
+    @SerialName("album") val album: Album? = null,
+)
+
+@Serializable
+data class Artist(@SerialName("id") val id: String? = null, @SerialName("name") val name: String)
+
+@Serializable
+data class Album(@SerialName("id") val id: String? = null, @SerialName("name") val name: String)
+
+@Serializable
+data class AudioFeaturesResponse(
+    @SerialName("audio_features") val audioFeatures: List<AudioFeatures?>
+)
+
+@Serializable
+data class AudioFeatures(
+    @SerialName("id") val id: String,
+    @SerialName("uri") val uri: String? = null,
+    @SerialName("tempo") val tempo: Float,
+    @SerialName("energy") val energy: Float? = null,
+    @SerialName("danceability") val danceability: Float? = null,
+    @SerialName("duration_ms") val durationMs: Long? = null,
+)
+
+@Serializable
+data class CreatePlaylistBody(
+    @SerialName("name") val name: String,
+    @SerialName("public") val public: Boolean = false,
+    @SerialName("description") val description: String? = null,
+)
+
+@Serializable
+data class Playlist(
+    @SerialName("id") val id: String,
+    @SerialName("uri") val uri: String,
+    @SerialName("name") val name: String,
+)
+
+@Serializable data class AddTracksBody(@SerialName("uris") val uris: List<String>)
+
+@Serializable data class AddTracksResponse(@SerialName("snapshot_id") val snapshotId: String)

--- a/app/src/main/java/dk/dittmann/spotifypacer/spotify/SpotifyTokenProvider.kt
+++ b/app/src/main/java/dk/dittmann/spotifypacer/spotify/SpotifyTokenProvider.kt
@@ -1,0 +1,13 @@
+package dk.dittmann.spotifypacer.spotify
+
+/**
+ * Synchronous token source for the Spotify API client. Implementations bridge to the auth module —
+ * keeping this interface here decouples the API client from auth wiring.
+ */
+interface SpotifyTokenProvider {
+    /** Returns a non-expired access token, or null if a refresh is required. */
+    fun currentAccessToken(): String?
+
+    /** Forces a refresh and returns the new access token. May block on I/O. */
+    fun refreshAccessToken(): String
+}

--- a/app/src/test/java/dk/dittmann/spotifypacer/spotify/SpotifyApiTest.kt
+++ b/app/src/test/java/dk/dittmann/spotifypacer/spotify/SpotifyApiTest.kt
@@ -191,6 +191,24 @@ class SpotifyApiTest {
     }
 
     @Test
+    fun rate_limit_429_without_retry_after_is_not_retried() = runTest {
+        val sleeps = mutableListOf<Long>()
+        val testApi =
+            buildApi(tokens = tokens, rateLimit = RateLimitInterceptor(sleeper = { sleeps += it }))
+
+        server.enqueue(MockResponse().setResponseCode(429))
+
+        try {
+            testApi.me()
+            org.junit.Assert.fail("Expected HttpException for unretried 429")
+        } catch (expected: retrofit2.HttpException) {
+            assertEquals(429, expected.code())
+        }
+        assertTrue(sleeps.isEmpty())
+        assertEquals(1, server.requestCount)
+    }
+
+    @Test
     fun unauthorized_401_triggers_one_refresh_and_retry() = runTest {
         var current: String? = "stale-token"
         val refreshes = mutableListOf<String>()

--- a/app/src/test/java/dk/dittmann/spotifypacer/spotify/SpotifyApiTest.kt
+++ b/app/src/test/java/dk/dittmann/spotifypacer/spotify/SpotifyApiTest.kt
@@ -1,0 +1,245 @@
+package dk.dittmann.spotifypacer.spotify
+
+import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import retrofit2.Retrofit
+
+class SpotifyApiTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var api: SpotifyApi
+    private val tokens =
+        object : SpotifyTokenProvider {
+            override fun currentAccessToken(): String? = "access-token"
+
+            override fun refreshAccessToken(): String = "access-token"
+        }
+
+    @Before
+    fun setup() {
+        server = MockWebServer().also { it.start() }
+        api = SpotifyApiFactory.create(tokens = tokens, baseUrl = server.url("/").toString())
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    @Test
+    fun me_parses_user_profile_and_sends_bearer() = runTest {
+        server.enqueue(
+            MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setBody("""{"id":"user-1","display_name":"Seb"}""")
+        )
+
+        val profile = api.me()
+
+        assertEquals("user-1", profile.id)
+        assertEquals("Seb", profile.displayName)
+        val recorded = server.takeRequest()
+        assertEquals("/v1/me", recorded.path)
+        assertEquals("Bearer access-token", recorded.getHeader("Authorization"))
+    }
+
+    @Test
+    fun savedTracks_sends_pagination_and_parses_page() = runTest {
+        server.enqueue(
+            MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setBody(
+                    """
+                    {
+                      "items": [
+                        {
+                          "added_at": "2024-01-01T00:00:00Z",
+                          "track": {
+                            "id": "t1",
+                            "uri": "spotify:track:t1",
+                            "name": "Run",
+                            "duration_ms": 240000,
+                            "artists": [{"id":"a1","name":"Artist"}],
+                            "album": {"id":"al1","name":"Album"}
+                          }
+                        }
+                      ],
+                      "total": 100,
+                      "limit": 50,
+                      "offset": 0,
+                      "next": "https://api.spotify.com/v1/me/tracks?offset=50&limit=50"
+                    }
+                    """
+                        .trimIndent()
+                )
+        )
+
+        val page = api.savedTracks(limit = 50, offset = 0)
+
+        assertEquals(100, page.total)
+        assertEquals(1, page.items.size)
+        assertEquals("spotify:track:t1", page.items[0].track.uri)
+        assertEquals("Artist", page.items[0].track.artists[0].name)
+        val recorded = server.takeRequest()
+        assertEquals("/v1/me/tracks?limit=50&offset=0", recorded.path)
+    }
+
+    @Test
+    fun audioFeatures_sends_comma_separated_ids() = runTest {
+        server.enqueue(
+            MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setBody(
+                    """
+                    {
+                      "audio_features": [
+                        {"id":"t1","tempo":172.5,"energy":0.8,"duration_ms":240000},
+                        null
+                      ]
+                    }
+                    """
+                        .trimIndent()
+                )
+        )
+
+        val response = api.audioFeatures(ids = "t1,t2")
+
+        assertEquals(2, response.audioFeatures.size)
+        assertEquals(172.5f, response.audioFeatures[0]!!.tempo, 0.001f)
+        assertNull(response.audioFeatures[1])
+        val recorded = server.takeRequest()
+        assertEquals("/v1/audio-features?ids=t1%2Ct2", recorded.path)
+    }
+
+    @Test
+    fun createPlaylist_posts_body_and_parses_response() = runTest {
+        server.enqueue(
+            MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setResponseCode(201)
+                .setBody("""{"id":"p1","uri":"spotify:playlist:p1","name":"5km pacer"}""")
+        )
+
+        val playlist =
+            api.createPlaylist(
+                userId = "user-1",
+                body = CreatePlaylistBody(name = "5km pacer", description = "desc"),
+            )
+
+        assertEquals("p1", playlist.id)
+        assertEquals("spotify:playlist:p1", playlist.uri)
+        val recorded = server.takeRequest()
+        assertEquals("POST", recorded.method)
+        assertEquals("/v1/users/user-1/playlists", recorded.path)
+        val body = recorded.body.readUtf8()
+        assertTrue(body.contains("\"name\":\"5km pacer\""))
+        assertTrue(body.contains("\"description\":\"desc\""))
+    }
+
+    @Test
+    fun addTracks_posts_uris_and_parses_snapshot() = runTest {
+        server.enqueue(
+            MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setResponseCode(201)
+                .setBody("""{"snapshot_id":"snap-1"}""")
+        )
+
+        val response =
+            api.addTracks(
+                playlistId = "p1",
+                body = AddTracksBody(uris = listOf("spotify:track:t1", "spotify:track:t2")),
+            )
+
+        assertEquals("snap-1", response.snapshotId)
+        val recorded = server.takeRequest()
+        assertEquals("POST", recorded.method)
+        assertEquals("/v1/playlists/p1/tracks", recorded.path)
+        val body = recorded.body.readUtf8()
+        assertTrue(body.contains("spotify:track:t1"))
+        assertTrue(body.contains("spotify:track:t2"))
+    }
+
+    @Test
+    fun rate_limit_429_is_retried_after_sleeping() = runTest {
+        val sleeps = mutableListOf<Long>()
+        val testApi =
+            buildApi(tokens = tokens, rateLimit = RateLimitInterceptor(sleeper = { sleeps += it }))
+
+        server.enqueue(MockResponse().setResponseCode(429).setHeader("Retry-After", "2"))
+        server.enqueue(
+            MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setBody("""{"id":"u","display_name":null}""")
+        )
+
+        val profile = testApi.me()
+
+        assertEquals("u", profile.id)
+        assertEquals(listOf(2_000L), sleeps)
+    }
+
+    @Test
+    fun unauthorized_401_triggers_one_refresh_and_retry() = runTest {
+        var current: String? = "stale-token"
+        val refreshes = mutableListOf<String>()
+        val provider =
+            object : SpotifyTokenProvider {
+                override fun currentAccessToken(): String? = current
+
+                override fun refreshAccessToken(): String {
+                    val fresh = "fresh-token"
+                    current = fresh
+                    refreshes += fresh
+                    return fresh
+                }
+            }
+        val refreshingApi =
+            SpotifyApiFactory.create(tokens = provider, baseUrl = server.url("/").toString())
+
+        server.enqueue(MockResponse().setResponseCode(401))
+        server.enqueue(
+            MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setBody("""{"id":"u","display_name":null}""")
+        )
+
+        val profile = refreshingApi.me()
+
+        assertEquals("u", profile.id)
+        assertEquals(listOf("fresh-token"), refreshes)
+        val first = server.takeRequest()
+        val second = server.takeRequest()
+        assertEquals("Bearer stale-token", first.getHeader("Authorization"))
+        assertEquals("Bearer fresh-token", second.getHeader("Authorization"))
+    }
+
+    private fun buildApi(
+        tokens: SpotifyTokenProvider,
+        rateLimit: RateLimitInterceptor = RateLimitInterceptor(),
+    ): SpotifyApi {
+        val client =
+            OkHttpClient.Builder()
+                .addInterceptor(SpotifyAuthInterceptor(tokens))
+                .addInterceptor(rateLimit)
+                .build()
+        val json = Json { ignoreUnknownKeys = true }
+        return Retrofit.Builder()
+            .baseUrl(server.url("/"))
+            .client(client)
+            .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+            .build()
+            .create(SpotifyApi::class.java)
+    }
+}

--- a/app/src/test/java/dk/dittmann/spotifypacer/spotify/SpotifyClientTest.kt
+++ b/app/src/test/java/dk/dittmann/spotifypacer/spotify/SpotifyClientTest.kt
@@ -1,0 +1,81 @@
+package dk.dittmann.spotifypacer.spotify
+
+import kotlinx.coroutines.test.runTest
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class SpotifyClientTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var client: SpotifyClient
+
+    private val tokens =
+        object : SpotifyTokenProvider {
+            override fun currentAccessToken(): String? = "t"
+
+            override fun refreshAccessToken(): String = "t"
+        }
+
+    @Before
+    fun setup() {
+        server = MockWebServer().also { it.start() }
+        val api = SpotifyApiFactory.create(tokens = tokens, baseUrl = server.url("/").toString())
+        client = SpotifyClient(api)
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    @Test
+    fun audioFeatures_chunks_ids_into_batches_of_100() = runTest {
+        val ids = (1..150).map { "id$it" }
+        repeat(2) {
+            server.enqueue(
+                MockResponse()
+                    .setHeader("Content-Type", "application/json")
+                    .setBody("""{"audio_features":[]}""")
+            )
+        }
+
+        client.audioFeatures(ids)
+
+        val first = server.takeRequest()
+        val second = server.takeRequest()
+        val firstIds = first.requestUrl!!.queryParameter("ids")!!
+        val secondIds = second.requestUrl!!.queryParameter("ids")!!
+        assertEquals(100, firstIds.split(",").size)
+        assertEquals(50, secondIds.split(",").size)
+    }
+
+    @Test
+    fun addTracks_chunks_uris_into_batches_of_100_and_returns_snapshot_per_batch() = runTest {
+        val uris = (1..150).map { "spotify:track:t$it" }
+        server.enqueue(
+            MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setResponseCode(201)
+                .setBody("""{"snapshot_id":"s1"}""")
+        )
+        server.enqueue(
+            MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setResponseCode(201)
+                .setBody("""{"snapshot_id":"s2"}""")
+        )
+
+        val snapshots = client.addTracks(playlistId = "p1", uris = uris)
+
+        assertEquals(listOf("s1", "s2"), snapshots)
+        val firstBody = server.takeRequest().body.readUtf8()
+        val secondBody = server.takeRequest().body.readUtf8()
+        // Crude size check: each batch should serialize 100 / 50 uris respectively.
+        assertEquals(100, "spotify:track:".toRegex().findAll(firstBody).count())
+        assertEquals(50, "spotify:track:".toRegex().findAll(secondBody).count())
+    }
+}


### PR DESCRIPTION
Closes #3.

Thin Retrofit + kotlinx.serialization client for the Spotify Web API endpoints the playlist generator needs.

## What

- `SpotifyApi` (Retrofit interface): `GET /me`, `GET /me/tracks`, `GET /audio-features`, `POST /users/{id}/playlists`, `POST /playlists/{id}/tracks`.
- `SpotifyAuthInterceptor`: attaches `Bearer` token; on 401, refreshes once via `SpotifyTokenProvider` and retries.
- `RateLimitInterceptor`: on 429, sleeps for `Retry-After` seconds and retries once.
- `SpotifyClient` facade: chunks `audio-features` ids and add-tracks uris into 100-item batches.
- DTOs in `SpotifyDtos.kt` covering the response shapes used by the above.

## Why

This is the foundation for the save-playlist flow (#9) and for feeding the track selection algorithm with audio features. `SpotifyTokenProvider` is a small interface to keep the API module decoupled from the auth module — the auth → provider adapter wires up at composition time when we add DI.

## Tests

`MockWebServer` covers one happy path per endpoint, the 429 `Retry-After` retry, the 401 refresh-and-retry, and the batching helpers. `./gradlew :app:testDebugUnitTest spotlessCheck` is green.

## Notes

- `audio-features` is deprecated for new app registrations (late 2024). If a fresh client returns 404 here we'll need to revisit the BPM source — flagged in #3 and design docs.