### PR TITLE
feat: save approved selection as Spotify playlist

### DIFF
--- a/app/src/main/java/dk/dittmann/spotifypacer/save/PlaylistNaming.kt
+++ b/app/src/main/java/dk/dittmann/spotifypacer/save/PlaylistNaming.kt
@@ -1,0 +1,40 @@
+package dk.dittmann.spotifypacer.save
+
+import dk.dittmann.spotifypacer.pacing.PaceStrategy
+import dk.dittmann.spotifypacer.ui.setup.RunConfig
+
+/**
+ * Single source of truth for user-facing playlist names and descriptions, per ticket #9. Anything
+ * that needs to format a strategy, distance, or duration goes through here so the wording stays
+ * consistent.
+ */
+object PlaylistNaming {
+
+    fun name(config: RunConfig): String =
+        "Pacer · ${formatDistance(config.distanceKm)} · ${formatTime(config.targetTimeSec)} · ${strategyLabel(config.strategy)}"
+
+    fun description(strategy: PaceStrategy, totalSec: Int): String =
+        "${strategyLabel(strategy)} pace, total ${formatTime(totalSec)}"
+
+    fun trackUri(trackId: String): String = "spotify:track:$trackId"
+
+    fun playlistUrl(playlistId: String): String = "https://open.spotify.com/playlist/$playlistId"
+
+    private fun formatDistance(km: Double): String {
+        val whole = km.toLong()
+        return if (km == whole.toDouble()) "${whole}km" else "%.2fkm".format(km)
+    }
+
+    private fun formatTime(totalSec: Int): String {
+        val m = totalSec / 60
+        val s = totalSec % 60
+        return "%d:%02d".format(m, s)
+    }
+
+    private fun strategyLabel(strategy: PaceStrategy): String =
+        when (strategy) {
+            is PaceStrategy.Constant -> "constant"
+            is PaceStrategy.LinearRamp -> "linear"
+            is PaceStrategy.DelayedExponential -> "delayed-exp"
+        }
+}

--- a/app/src/main/java/dk/dittmann/spotifypacer/save/PlaylistNaming.kt
+++ b/app/src/main/java/dk/dittmann/spotifypacer/save/PlaylistNaming.kt
@@ -2,11 +2,11 @@ package dk.dittmann.spotifypacer.save
 
 import dk.dittmann.spotifypacer.pacing.PaceStrategy
 import dk.dittmann.spotifypacer.ui.setup.RunConfig
+import java.util.Locale
 
 /**
- * Single source of truth for user-facing playlist names and descriptions, per ticket #9. Anything
- * that needs to format a strategy, distance, or duration goes through here so the wording stays
- * consistent.
+ * Single source of truth for user-facing playlist names and descriptions. Anything that needs to
+ * format a strategy, distance, or duration goes through here so the wording stays consistent.
  */
 object PlaylistNaming {
 
@@ -22,13 +22,13 @@ object PlaylistNaming {
 
     private fun formatDistance(km: Double): String {
         val whole = km.toLong()
-        return if (km == whole.toDouble()) "${whole}km" else "%.2fkm".format(km)
+        return if (km == whole.toDouble()) "${whole}km" else "%.2fkm".format(Locale.ROOT, km)
     }
 
     private fun formatTime(totalSec: Int): String {
         val m = totalSec / 60
         val s = totalSec % 60
-        return "%d:%02d".format(m, s)
+        return "%d:%02d".format(Locale.ROOT, m, s)
     }
 
     private fun strategyLabel(strategy: PaceStrategy): String =

--- a/app/src/main/java/dk/dittmann/spotifypacer/save/SavePlaylistResult.kt
+++ b/app/src/main/java/dk/dittmann/spotifypacer/save/SavePlaylistResult.kt
@@ -1,0 +1,20 @@
+package dk.dittmann.spotifypacer.save
+
+sealed interface SavePlaylistResult {
+
+    data class Success(val playlistUrl: String) : SavePlaylistResult
+
+    /**
+     * Something failed mid-flow. [playlistUrl] is set when the playlist itself was created before
+     * the failure (e.g. a track-add batch failed) so the UI can still link the user to the partial
+     * playlist.
+     */
+    data class Failure(val stage: Stage, val cause: Throwable, val playlistUrl: String? = null) :
+        SavePlaylistResult
+
+    enum class Stage {
+        FETCH_USER,
+        CREATE_PLAYLIST,
+        ADD_TRACKS,
+    }
+}

--- a/app/src/main/java/dk/dittmann/spotifypacer/save/SavePlaylistUseCase.kt
+++ b/app/src/main/java/dk/dittmann/spotifypacer/save/SavePlaylistUseCase.kt
@@ -1,0 +1,53 @@
+package dk.dittmann.spotifypacer.save
+
+import dk.dittmann.spotifypacer.pacing.Selection
+import dk.dittmann.spotifypacer.spotify.SpotifyClient
+import dk.dittmann.spotifypacer.ui.setup.RunConfig
+
+/**
+ * Saves an approved [Selection] as a new private Spotify playlist for the signed-in user.
+ *
+ * The flow is sequential — fetch user → create playlist → add tracks — and each stage maps to a
+ * [SavePlaylistResult.Stage] so callers can show targeted error messages. Track-add failures keep
+ * the partial playlist URL because the playlist is already visible in the user's library at that
+ * point.
+ */
+class SavePlaylistUseCase(private val client: SpotifyClient) {
+
+    suspend operator fun invoke(config: RunConfig, selection: Selection): SavePlaylistResult {
+        val userId =
+            runCatching { client.me().id }
+                .getOrElse { e ->
+                    return SavePlaylistResult.Failure(SavePlaylistResult.Stage.FETCH_USER, e)
+                }
+
+        val playlist =
+            runCatching {
+                    client.createPlaylist(
+                        userId = userId,
+                        name = PlaylistNaming.name(config),
+                        description =
+                            PlaylistNaming.description(config.strategy, selection.totalSec),
+                        public = false,
+                    )
+                }
+                .getOrElse { e ->
+                    return SavePlaylistResult.Failure(SavePlaylistResult.Stage.CREATE_PLAYLIST, e)
+                }
+
+        val playlistUrl = PlaylistNaming.playlistUrl(playlist.id)
+        val uris = selection.tracks.map { PlaylistNaming.trackUri(it.track.id) }
+
+        return runCatching { client.addTracks(playlist.id, uris) }
+            .fold(
+                onSuccess = { SavePlaylistResult.Success(playlistUrl) },
+                onFailure = { e ->
+                    SavePlaylistResult.Failure(
+                        stage = SavePlaylistResult.Stage.ADD_TRACKS,
+                        cause = e,
+                        playlistUrl = playlistUrl,
+                    )
+                },
+            )
+    }
+}

--- a/app/src/test/java/dk/dittmann/spotifypacer/save/PlaylistNamingTest.kt
+++ b/app/src/test/java/dk/dittmann/spotifypacer/save/PlaylistNamingTest.kt
@@ -1,0 +1,60 @@
+package dk.dittmann.spotifypacer.save
+
+import dk.dittmann.spotifypacer.pacing.PaceStrategy
+import dk.dittmann.spotifypacer.ui.setup.RunConfig
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PlaylistNamingTest {
+
+    @Test
+    fun name_uses_dot_separator_and_human_strategy_label() {
+        val name =
+            PlaylistNaming.name(
+                RunConfig(
+                    distanceKm = 5.0,
+                    targetTimeSec = 28 * 60,
+                    strategy = PaceStrategy.DelayedExponential(),
+                )
+            )
+        assertEquals("Pacer · 5km · 28:00 · delayed-exp", name)
+    }
+
+    @Test
+    fun name_renders_decimal_distance_with_two_places() {
+        val name =
+            PlaylistNaming.name(
+                RunConfig(
+                    distanceKm = 5.5,
+                    targetTimeSec = 30 * 60 + 5,
+                    strategy = PaceStrategy.LinearRamp,
+                )
+            )
+        assertEquals("Pacer · 5.50km · 30:05 · linear", name)
+    }
+
+    @Test
+    fun name_handles_constant_strategy_label() {
+        val name =
+            PlaylistNaming.name(
+                RunConfig(distanceKm = 10.0, targetTimeSec = 3600, strategy = PaceStrategy.Constant)
+            )
+        assertEquals("Pacer · 10km · 60:00 · constant", name)
+    }
+
+    @Test
+    fun description_includes_strategy_and_total_duration() {
+        val description = PlaylistNaming.description(PaceStrategy.LinearRamp, totalSec = 1685)
+        assertEquals("linear pace, total 28:05", description)
+    }
+
+    @Test
+    fun trackUri_prefixes_with_spotify_track() {
+        assertEquals("spotify:track:abc", PlaylistNaming.trackUri("abc"))
+    }
+
+    @Test
+    fun playlistUrl_uses_open_spotify_host() {
+        assertEquals("https://open.spotify.com/playlist/xyz", PlaylistNaming.playlistUrl("xyz"))
+    }
+}

--- a/app/src/test/java/dk/dittmann/spotifypacer/save/SavePlaylistUseCaseTest.kt
+++ b/app/src/test/java/dk/dittmann/spotifypacer/save/SavePlaylistUseCaseTest.kt
@@ -1,0 +1,190 @@
+package dk.dittmann.spotifypacer.save
+
+import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
+import dk.dittmann.spotifypacer.pacing.CandidateTrack
+import dk.dittmann.spotifypacer.pacing.PaceStrategy
+import dk.dittmann.spotifypacer.pacing.SelectedTrack
+import dk.dittmann.spotifypacer.pacing.Selection
+import dk.dittmann.spotifypacer.spotify.RateLimitInterceptor
+import dk.dittmann.spotifypacer.spotify.SpotifyApi
+import dk.dittmann.spotifypacer.spotify.SpotifyAuthInterceptor
+import dk.dittmann.spotifypacer.spotify.SpotifyClient
+import dk.dittmann.spotifypacer.spotify.SpotifyTokenProvider
+import dk.dittmann.spotifypacer.ui.setup.RunConfig
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import retrofit2.Retrofit
+
+class SavePlaylistUseCaseTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var useCase: SavePlaylistUseCase
+    private val sleeps = mutableListOf<Long>()
+
+    private val tokens =
+        object : SpotifyTokenProvider {
+            override fun currentAccessToken(): String? = "t"
+
+            override fun refreshAccessToken(): String = "t"
+        }
+
+    @Before
+    fun setup() {
+        server = MockWebServer().also { it.start() }
+        // Build the API directly (instead of via SpotifyApiFactory) so we can swap in a no-op
+        // sleeper for the rate-limit interceptor and keep tests fast.
+        val okHttp =
+            OkHttpClient.Builder()
+                .addInterceptor(SpotifyAuthInterceptor(tokens))
+                .addInterceptor(RateLimitInterceptor(sleeper = { ms -> sleeps += ms }))
+                .build()
+        val json = Json { ignoreUnknownKeys = true }
+        val api =
+            Retrofit.Builder()
+                .baseUrl(server.url("/").toString())
+                .client(okHttp)
+                .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+                .build()
+                .create(SpotifyApi::class.java)
+        useCase = SavePlaylistUseCase(SpotifyClient(api))
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    private fun selection(count: Int): Selection {
+        val tracks =
+            (1..count).map {
+                SelectedTrack(
+                    track =
+                        CandidateTrack(
+                            id = "t$it",
+                            title = "T$it",
+                            artist = "A",
+                            bpm = 170.0,
+                            durationSec = 200,
+                        ),
+                    startSec = (it - 1) * 200,
+                )
+            }
+        return Selection(tracks = tracks, totalSec = count * 200)
+    }
+
+    private val config =
+        RunConfig(distanceKm = 5.0, targetTimeSec = 28 * 60, strategy = PaceStrategy.LinearRamp)
+
+    private fun jsonResponse(code: Int, body: String) =
+        MockResponse()
+            .setHeader("Content-Type", "application/json")
+            .setResponseCode(code)
+            .setBody(body)
+
+    @Test
+    fun happy_path_creates_playlist_then_adds_tracks_in_batches() = runTest {
+        server.enqueue(jsonResponse(200, """{"id":"u1"}"""))
+        server.enqueue(jsonResponse(201, """{"id":"p1","uri":"spotify:playlist:p1","name":"n"}"""))
+        // 150 tracks → 2 batches (100 + 50).
+        server.enqueue(jsonResponse(201, """{"snapshot_id":"s1"}"""))
+        server.enqueue(jsonResponse(201, """{"snapshot_id":"s2"}"""))
+
+        val result = useCase(config, selection(150))
+
+        assertEquals(SavePlaylistResult.Success("https://open.spotify.com/playlist/p1"), result)
+
+        assertEquals("/v1/me", server.takeRequest().path)
+
+        val createReq = server.takeRequest()
+        assertEquals("/v1/users/u1/playlists", createReq.path)
+        val createBody = Json.parseToJsonElement(createReq.body.readUtf8()).jsonObject
+        assertEquals("Pacer · 5km · 28:00 · linear", createBody["name"]!!.jsonPrimitive.content)
+        assertTrue(createBody["description"]!!.jsonPrimitive.content.contains("linear pace, total"))
+
+        val firstAdd = server.takeRequest()
+        assertEquals("/v1/playlists/p1/tracks", firstAdd.path)
+        assertEquals(100, "spotify:track:".toRegex().findAll(firstAdd.body.readUtf8()).count())
+
+        val secondAdd = server.takeRequest()
+        assertEquals(50, "spotify:track:".toRegex().findAll(secondAdd.body.readUtf8()).count())
+    }
+
+    @Test
+    fun batch_failure_returns_failure_with_partial_playlist_url() = runTest {
+        server.enqueue(jsonResponse(200, """{"id":"u1"}"""))
+        server.enqueue(jsonResponse(201, """{"id":"p1","uri":"spotify:playlist:p1","name":"n"}"""))
+        server.enqueue(jsonResponse(201, """{"snapshot_id":"s1"}"""))
+        server.enqueue(jsonResponse(500, """{"error":{"status":500,"message":"boom"}}"""))
+
+        val result = useCase(config, selection(150))
+
+        result as SavePlaylistResult.Failure
+        assertEquals(SavePlaylistResult.Stage.ADD_TRACKS, result.stage)
+        assertEquals("https://open.spotify.com/playlist/p1", result.playlistUrl)
+    }
+
+    @Test
+    fun create_playlist_failure_has_no_playlist_url() = runTest {
+        server.enqueue(jsonResponse(200, """{"id":"u1"}"""))
+        server.enqueue(jsonResponse(403, """{"error":{"status":403,"message":"forbidden"}}"""))
+
+        val result = useCase(config, selection(3))
+
+        result as SavePlaylistResult.Failure
+        assertEquals(SavePlaylistResult.Stage.CREATE_PLAYLIST, result.stage)
+        assertEquals(null, result.playlistUrl)
+    }
+
+    @Test
+    fun fetch_user_failure_short_circuits_before_create() = runTest {
+        server.enqueue(jsonResponse(500, """{"error":{"status":500,"message":"boom"}}"""))
+
+        val result = useCase(config, selection(3))
+
+        result as SavePlaylistResult.Failure
+        assertEquals(SavePlaylistResult.Stage.FETCH_USER, result.stage)
+        assertEquals(1, server.requestCount)
+    }
+
+    @Test
+    fun rate_limited_request_is_retried_after_retry_after_header() = runTest {
+        server.enqueue(jsonResponse(200, """{"id":"u1"}"""))
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(429)
+                .setHeader("Retry-After", "1")
+                .setHeader("Content-Type", "application/json")
+                .setBody("""{"error":{"status":429,"message":"slow down"}}""")
+        )
+        server.enqueue(jsonResponse(201, """{"id":"p1","uri":"spotify:playlist:p1","name":"n"}"""))
+        server.enqueue(jsonResponse(201, """{"snapshot_id":"s1"}"""))
+
+        val result = useCase(config, selection(3))
+
+        assertEquals(SavePlaylistResult.Success("https://open.spotify.com/playlist/p1"), result)
+        assertEquals(listOf(1000L), sleeps)
+        assertEquals(4, server.requestCount)
+    }
+
+    @Test
+    fun empty_selection_skips_add_tracks_call() = runTest {
+        server.enqueue(jsonResponse(200, """{"id":"u1"}"""))
+        server.enqueue(jsonResponse(201, """{"id":"p1","uri":"spotify:playlist:p1","name":"n"}"""))
+
+        val result = useCase(config, Selection(emptyList(), totalSec = 0))
+
+        assertEquals(SavePlaylistResult.Success("https://open.spotify.com/playlist/p1"), result)
+        assertEquals(2, server.requestCount)
+    }
+}


### PR DESCRIPTION
Implements #9 — saves the approved selection as a private playlist on the signed-in user's Spotify account.

## What's new

- `dk.dittmann.spotifypacer.save` package
  - `PlaylistNaming` — single source of truth for the `Pacer · {distance} · {time} · {strategy}` name template, the description (`{strategy} pace, total {mm:ss}`), the `spotify:track:{id}` URI prefix, and the public playlist URL.
  - `SavePlaylistUseCase` — orchestrates `/v1/me` → `POST /v1/users/{id}/playlists` → `POST /v1/playlists/{id}/tracks`. Track batching (chunks of 100) and 429 retries are already handled by `SpotifyClient` and `RateLimitInterceptor`, so this stays focused on flow + error mapping.
  - `SavePlaylistResult` — sealed result carrying the failing `Stage` (FETCH_USER / CREATE_PLAYLIST / ADD_TRACKS) and the partial playlist URL on track-add failures so the UI can still link the user to the half-saved playlist.

## Tests

`SavePlaylistUseCaseTest` (MockWebServer) covers:
- happy path — verifies `/me` → create → two add-tracks batches (100 + 50) and JSON name + description on the create body
- batch failure on the second add-tracks call returns `Failure(ADD_TRACKS, playlistUrl=...)`
- create-playlist failure returns `Failure(CREATE_PLAYLIST, playlistUrl=null)`
- fetch-user failure short-circuits before create
- 429 with `Retry-After: 1` is retried (via the existing `RateLimitInterceptor`, with a no-op sleeper)
- empty selection skips the add-tracks call

`PlaylistNamingTest` covers strategy labels, decimal vs whole km, time formatting, URI/URL prefixes.

## Out of scope

- Wiring into the (not-yet-built) preview screen and ViewModel — that lands with #8.
- Cover-art upload and collaborative playlists.

Closes #9