### PR TITLE
fix: finish AuthRedirectActivity synchronously to avoid onResume crash

### DIFF
--- a/app/src/main/java/dk/dittmann/spotifypacer/SpotifyPacerApplication.kt
+++ b/app/src/main/java/dk/dittmann/spotifypacer/SpotifyPacerApplication.kt
@@ -5,10 +5,15 @@ import dk.dittmann.spotifypacer.auth.AuthApiFactory
 import dk.dittmann.spotifypacer.auth.AuthService
 import dk.dittmann.spotifypacer.auth.EncryptedTokenStore
 import dk.dittmann.spotifypacer.auth.TokenStore
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 
 class SpotifyPacerApplication : Application() {
 
     val tokenStore: TokenStore by lazy { EncryptedTokenStore(applicationContext) }
+
+    val applicationScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     val authService: AuthService by lazy {
         AuthService(

--- a/app/src/main/java/dk/dittmann/spotifypacer/auth/AuthRedirectActivity.kt
+++ b/app/src/main/java/dk/dittmann/spotifypacer/auth/AuthRedirectActivity.kt
@@ -2,33 +2,32 @@ package dk.dittmann.spotifypacer.auth
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
-import androidx.lifecycle.lifecycleScope
 import dk.dittmann.spotifypacer.SpotifyPacerApplication
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
+/**
+ * Theme.NoDisplay activity that handles the OAuth redirect. Must call finish() before onResume()
+ * returns or Android crashes the app, so the token exchange is dispatched onto the application
+ * scope and this activity finishes synchronously. Login UI observes [AuthService.isAuthenticated]
+ * to react when the exchange completes.
+ */
 class AuthRedirectActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val data = intent?.data
-        if (data == null) {
-            finish()
-            return
-        }
-        val service = (application as SpotifyPacerApplication).authService
-        lifecycleScope.launch {
-            withContext(Dispatchers.IO) {
+        if (data != null) {
+            val app = application as SpotifyPacerApplication
+            app.applicationScope.launch {
                 runCatching {
-                    service.completeAuthorize(
+                    app.authService.completeAuthorize(
                         code = data.getQueryParameter("code"),
                         state = data.getQueryParameter("state"),
                         spotifyError = data.getQueryParameter("error"),
                     )
                 }
             }
-            finish()
         }
+        finish()
     }
 }

--- a/app/src/main/java/dk/dittmann/spotifypacer/auth/AuthRedirectActivity.kt
+++ b/app/src/main/java/dk/dittmann/spotifypacer/auth/AuthRedirectActivity.kt
@@ -1,7 +1,9 @@
 package dk.dittmann.spotifypacer.auth
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import dk.dittmann.spotifypacer.MainActivity
 import dk.dittmann.spotifypacer.SpotifyPacerApplication
 import kotlinx.coroutines.launch
 
@@ -10,6 +12,9 @@ import kotlinx.coroutines.launch
  * returns or Android crashes the app, so the token exchange is dispatched onto the application
  * scope and this activity finishes synchronously. Login UI observes [AuthService.isAuthenticated]
  * to react when the exchange completes.
+ *
+ * After processing, MainActivity is brought back to the front so the user returns to the app
+ * instead of staring at the now-stale Custom Tabs page.
  */
 class AuthRedirectActivity : ComponentActivity() {
 
@@ -28,6 +33,11 @@ class AuthRedirectActivity : ComponentActivity() {
                 }
             }
         }
+        startActivity(
+            Intent(this, MainActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
+            }
+        )
         finish()
     }
 }

--- a/app/src/main/java/dk/dittmann/spotifypacer/auth/AuthService.kt
+++ b/app/src/main/java/dk/dittmann/spotifypacer/auth/AuthService.kt
@@ -2,6 +2,9 @@ package dk.dittmann.spotifypacer.auth
 
 import java.security.SecureRandom
 import java.util.UUID
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
 
@@ -19,6 +22,9 @@ class AuthService(
     @Volatile private var accessToken: String? = null
     @Volatile private var accessTokenExpiresAt: Long = 0L
     private var pending: PendingAuth? = null
+
+    private val _isAuthenticated = MutableStateFlow(tokenStore.readRefreshToken() != null)
+    val isAuthenticated: StateFlow<Boolean> = _isAuthenticated.asStateFlow()
 
     fun prepareAuthorize(): HttpUrl {
         val verifier = PkceGenerator.generateCodeVerifier(random)
@@ -83,11 +89,13 @@ class AuthService(
         accessToken = null
         accessTokenExpiresAt = 0L
         pending = null
+        _isAuthenticated.value = false
     }
 
     private fun applyTokenResponse(response: TokenResponse) {
         accessToken = response.accessToken
         accessTokenExpiresAt = clock() + response.expiresIn * 1000L
+        _isAuthenticated.value = true
     }
 
     companion object {

--- a/app/src/main/java/dk/dittmann/spotifypacer/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/dk/dittmann/spotifypacer/ui/login/LoginViewModel.kt
@@ -1,30 +1,49 @@
 package dk.dittmann.spotifypacer.ui.login
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import dk.dittmann.spotifypacer.auth.AuthService
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.launch
 
 /**
  * Drives the login screen. Owns the screen state but delegates the actual sign-in launch to a
  * [SignInLauncher] so the auth flow's Activity dependency stays out of the ViewModel.
  *
  * The auth dependency is a small token-snapshot lambda so tests don't need to reach into
- * [AuthService] internals.
+ * [AuthService] internals. [authStateChanges] surfaces token-store updates so the screen can react
+ * when the OAuth redirect completes (the redirect activity finishes immediately and the actual
+ * token exchange runs on the application scope).
  */
 class LoginViewModel(
     private val accessTokenSource: () -> String?,
     private val launcher: SignInLauncher,
+    authStateChanges: Flow<Boolean> = emptyFlow(),
 ) : ViewModel() {
 
     constructor(
         authService: AuthService,
         launcher: SignInLauncher,
-    ) : this(accessTokenSource = authService::currentAccessToken, launcher = launcher)
+    ) : this(
+        accessTokenSource = authService::currentAccessToken,
+        launcher = launcher,
+        authStateChanges = authService.isAuthenticated,
+    )
 
     private val _state = MutableStateFlow<LoginState>(LoginState.Idle)
     val state: StateFlow<LoginState> = _state.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            authStateChanges.collect { authenticated ->
+                if (authenticated) _state.value = LoginState.Success
+            }
+        }
+    }
 
     fun onSignInClicked() {
         _state.value = LoginState.Loading

--- a/app/src/test/java/dk/dittmann/spotifypacer/auth/AuthServiceTest.kt
+++ b/app/src/test/java/dk/dittmann/spotifypacer/auth/AuthServiceTest.kt
@@ -199,6 +199,76 @@ class AuthServiceTest {
     }
 
     @Test
+    fun isAuthenticated_initial_value_reflects_stored_refresh_token() {
+        val withToken = FakeTokenStore().also { it.saveRefreshToken("r") }
+        val service =
+            AuthService(
+                clientId = "cid",
+                redirectUri = "app://cb",
+                tokenStore = withToken,
+                api = AuthApiFactory.create(baseUrl = server.url("/").toString()),
+            )
+        assertEquals(true, service.isAuthenticated.value)
+
+        val empty =
+            AuthService(
+                clientId = "cid",
+                redirectUri = "app://cb",
+                tokenStore = FakeTokenStore(),
+                api = AuthApiFactory.create(baseUrl = server.url("/").toString()),
+            )
+        assertEquals(false, empty.isAuthenticated.value)
+    }
+
+    @Test
+    fun isAuthenticated_flips_true_after_successful_token_exchange() = runTest {
+        server.enqueue(
+            MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setBody(
+                    """
+                    {
+                      "access_token": "a",
+                      "token_type": "Bearer",
+                      "expires_in": 3600,
+                      "refresh_token": "r"
+                    }
+                    """
+                        .trimIndent()
+                )
+        )
+
+        assertEquals(false, authService.isAuthenticated.value)
+        authService.exchangeCode(code = "c", codeVerifier = "v")
+        assertEquals(true, authService.isAuthenticated.value)
+    }
+
+    @Test
+    fun isAuthenticated_flips_false_after_logout() = runTest {
+        tokenStore.saveRefreshToken("r")
+        server.enqueue(
+            MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setBody(
+                    """
+                    {
+                      "access_token": "a",
+                      "token_type": "Bearer",
+                      "expires_in": 3600
+                    }
+                    """
+                        .trimIndent()
+                )
+        )
+        authService.exchangeCode(code = "c", codeVerifier = "v")
+        assertEquals(true, authService.isAuthenticated.value)
+
+        authService.logout()
+
+        assertEquals(false, authService.isAuthenticated.value)
+    }
+
+    @Test
     fun prepareAuthorize_generates_pkce_and_state_and_returns_url() {
         nextState = "state-prep"
 

--- a/app/src/test/java/dk/dittmann/spotifypacer/ui/login/LoginViewModelTest.kt
+++ b/app/src/test/java/dk/dittmann/spotifypacer/ui/login/LoginViewModelTest.kt
@@ -1,21 +1,39 @@
 package dk.dittmann.spotifypacer.ui.login
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class LoginViewModelTest {
 
     private var token: String? = null
     private var launches = 0
     private var launchError: Throwable? = null
+    private val authState = MutableStateFlow(false)
 
     @Before
     fun setup() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
         token = null
         launches = 0
         launchError = null
+        authState.value = false
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
     }
 
     @Test
@@ -79,12 +97,33 @@ class LoginViewModelTest {
         assertEquals(errorBefore, vm.state.value)
     }
 
-    private fun newViewModel(): LoginViewModel =
+    @Test
+    fun authStateChanges_flip_loading_to_success_when_authenticated() {
+        val vm = newViewModel(authStateChanges = authState)
+        vm.onSignInClicked()
+        assertEquals(LoginState.Loading, vm.state.value)
+
+        authState.value = true
+
+        assertEquals(LoginState.Success, vm.state.value)
+    }
+
+    @Test
+    fun authStateChanges_emitting_false_does_not_change_state() {
+        val vm = newViewModel(authStateChanges = authState)
+
+        authState.value = false
+
+        assertEquals(LoginState.Idle, vm.state.value)
+    }
+
+    private fun newViewModel(authStateChanges: Flow<Boolean> = emptyFlow()): LoginViewModel =
         LoginViewModel(
             accessTokenSource = { token },
             launcher = {
                 launches++
                 launchError?.let { throw it }
             },
+            authStateChanges = authStateChanges,
         )
 }


### PR DESCRIPTION
## What

Fix login crash on the OAuth redirect activity. After the Spotify auth flow returns to the app, the process crashes with:

```
java.lang.IllegalStateException: Activity {.../AuthRedirectActivity} did not call finish() prior to onResume() completing
```

`AuthRedirectActivity` uses `@android:style/Theme.NoDisplay`. Android requires such activities to call `finish()` before `onResume()` returns. The previous implementation only called `finish()` inside a coroutine that suspended on the token-exchange HTTP call, so `onResume` completed first and the platform crashed the app.

## Changes

- `SpotifyPacerApplication`: add `applicationScope` (`SupervisorJob + Dispatchers.IO`) so token exchange survives the activity finishing.
- `AuthRedirectActivity`: dispatch `completeAuthorize` onto `applicationScope`, then `finish()` synchronously in `onCreate`.
- `AuthService`: expose `isAuthenticated: StateFlow<Boolean>`. Initialised from the persisted refresh token; flipped on token apply / logout.
- `LoginViewModel`: collect `isAuthenticated` so the login screen flips Loading → Success when the exchange completes (removes the race between the activity finishing and `LoginRoute` resuming before the token is stored).

## Tests

- `LoginViewModelTest`: add `Dispatchers.setMain` plumbing; new tests for the auth-state flow → Success transition.
- `AuthServiceTest`: new tests covering `isAuthenticated` initial value, post-exchange, and post-logout.
- `gradle spotlessApply :app:testDebugUnitTest :app:validateDebugScreenshotTest` all green.

Closes #36
